### PR TITLE
Add ability to specify personaId and contentChannelIds for Persona Feeds

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -70,9 +70,7 @@ const resolver = {
         args,
       }),
     personaFeed: async (root, args, { dataSources }) => {
-      const personaFeed = await dataSources.ContentItem.byPersonaFeed(
-        args.first
-      );
+      const personaFeed = await dataSources.ContentItem.byPersonaFeed(args);
       return dataSources.ContentItem.paginate({
         cursor: personaFeed,
         args,

--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -63,11 +63,15 @@ export default class Features extends RockApolloDataSource {
     };
   }
 
-  async personaFeedAlgorithm() {
+  async personaFeedAlgorithm({ personaId, contentChannelIds, first = 3 }) {
     const { ContentItem } = this.context.dataSources;
 
     // Get the first three persona items.
-    const personaFeed = await ContentItem.byPersonaFeed(3);
+    const personaFeed = await ContentItem.byPersonaFeed({
+      personaId,
+      first,
+      contentChannelIds,
+    });
     const items = await personaFeed.get();
 
     // Map them into specific actions.


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This is something I've been using on Willow to allow customization of the `personaId` and `contentChannelIds` selected for a `personaFeed`. 

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
