### PR TITLE
Ensure animated values are always the same in connected tests

### DIFF
--- a/packages/apollos-ui-connected/jest.setup.js
+++ b/packages/apollos-ui-connected/jest.setup.js
@@ -15,6 +15,27 @@ jest.mock(
   })
 );
 
+jest.mock('Animated', () => {
+  const ActualAnimated = require.requireActual('Animated');
+  return {
+    ...ActualAnimated,
+    timing: (value, config) => ({
+      start: (callback) => {
+        value.setValue(config.toValue);
+        callback && callback();
+      },
+      stop: () => ({}),
+    }),
+    spring: (value, config) => ({
+      start: (callback) => {
+        value.setValue(config.toValue);
+        callback && callback();
+      },
+      stop: () => ({}),
+    }),
+  };
+});
+
 NativeModules.RNGestureHandlerModule = {
   attachGestureHandler: jest.fn(),
   createGestureHandler: jest.fn(),

--- a/packages/apollos-ui-connected/jest.setup.js
+++ b/packages/apollos-ui-connected/jest.setup.js
@@ -15,6 +15,11 @@ jest.mock(
   })
 );
 
+jest.mock('Image', () => ({
+  ...require.requireActual('Image'),
+  getSize: (_, cb) => cb(500, 600),
+}));
+
 jest.mock('Animated', () => {
   const ActualAnimated = require.requireActual('Animated');
   return {

--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.tests.js
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.tests.js
@@ -24,7 +24,17 @@ const mock = {
                 videos: [],
                 theme: null,
                 summary: 'bla bla bla',
-                coverImage: null,
+                coverImage: {
+                  name: 'Square image',
+                  __typename: 'ImageMedia',
+                  sources: [
+                    {
+                      uri:
+                        'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2',
+                      __typename: 'ImageMediaSource',
+                    },
+                  ],
+                },
                 parentChannel: {
                   id: 'ContentChannel:559b23fd0aa90e81b1c023e72e230fa1',
                   name: 'Devotional',
@@ -52,7 +62,17 @@ const mock = {
                 videos: [],
                 theme: null,
                 summary: 'bla bla bla',
-                coverImage: null,
+                coverImage: {
+                  name: 'Square image',
+                  __typename: 'ImageMedia',
+                  sources: [
+                    {
+                      uri:
+                        'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2',
+                      __typename: 'ImageMediaSource',
+                    },
+                  ],
+                },
                 parentChannel: {
                   id: 'ContentChannel:559b23fd0aa90e81b1c023e72e230fa1',
                   name: 'Devotional',
@@ -81,7 +101,17 @@ const mock = {
                 videos: [],
                 theme: null,
                 summary: 'bla bla bla',
-                coverImage: null,
+                coverImage: {
+                  name: 'Square image',
+                  __typename: 'ImageMedia',
+                  sources: [
+                    {
+                      uri:
+                        'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2',
+                      __typename: 'ImageMediaSource',
+                    },
+                  ],
+                },
                 parentChannel: {
                   id: 'ContentChannel:559b23fd0aa90e81b1c023e72e230fa1',
                   name: 'Devotional',
@@ -109,7 +139,17 @@ const mock = {
                 videos: [],
                 theme: null,
                 summary: 'bla bla bla',
-                coverImage: null,
+                coverImage: {
+                  name: 'Square image',
+                  __typename: 'ImageMedia',
+                  sources: [
+                    {
+                      uri:
+                        'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2',
+                      __typename: 'ImageMediaSource',
+                    },
+                  ],
+                },
                 parentChannel: {
                   id: 'ContentChannel:559b23fd0aa90e81b1c023e72e230fa1',
                   name: 'Devotional',

--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
@@ -13,7 +13,15 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
     Array [
       Object {
         "__typename": "DevotionalContentItem",
-        "coverImage": Object {},
+        "coverImage": Object {
+          "__typename": "ImageMedia",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+            },
+          ],
+        },
         "hyphenatedTitle": "God sees who you can be not who you are",
         "id": "DevotionalContentItem:d395278cd4b68e074ca4e595c8feab6d",
         "parentChannel": Object {
@@ -28,7 +36,15 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
       },
       Object {
         "__typename": "DevotionalContentItem",
-        "coverImage": Object {},
+        "coverImage": Object {
+          "__typename": "ImageMedia",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+            },
+          ],
+        },
         "hyphenatedTitle": "Thank God for the friends who will tell it like it is",
         "id": "DevotionalContentItem:fbea6914a3e8877516cbd333d919075d",
         "parentChannel": Object {
@@ -43,7 +59,15 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
       },
       Object {
         "__typename": "DevotionalContentItem",
-        "coverImage": Object {},
+        "coverImage": Object {
+          "__typename": "ImageMedia",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+            },
+          ],
+        },
         "hyphenatedTitle": "No sin is too bad",
         "id": "DevotionalContentItem:5e18250f586ab8de4d3d6292c919dcc4",
         "parentChannel": Object {
@@ -58,7 +82,15 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
       },
       Object {
         "__typename": "DevotionalContentItem",
-        "coverImage": Object {},
+        "coverImage": Object {
+          "__typename": "ImageMedia",
+          "sources": Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+            },
+          ],
+        },
         "hyphenatedTitle": "Change starts with a choice",
         "id": "DevotionalContentItem:bdc2c29b85949e4ca8232b373a07953d",
         "parentChannel": Object {
@@ -202,12 +234,31 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                 }
               }
             >
-              <View
-                forceRatio={1}
+              <RCTImageView
+                customTheme={null}
+                disabled={false}
+                maxAspectRatio={1}
+                minAspectRatio={1}
+                onLoad={[Function]}
+                resizeMode="cover"
+                source={
+                  Array [
+                    Object {
+                      "__typename": "ImageMediaSource",
+                      "cache": "force-cache",
+                      "height": 600,
+                      "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+                      "width": 500,
+                    },
+                  ]
+                }
                 style={
                   Object {
                     "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
+                    "opacity": 0,
+                    "overflow": "hidden",
+                    "resizeMode": "cover",
                     "width": "100%",
                   }
                 }
@@ -380,12 +431,31 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                 }
               }
             >
-              <View
-                forceRatio={1}
+              <RCTImageView
+                customTheme={null}
+                disabled={false}
+                maxAspectRatio={1}
+                minAspectRatio={1}
+                onLoad={[Function]}
+                resizeMode="cover"
+                source={
+                  Array [
+                    Object {
+                      "__typename": "ImageMediaSource",
+                      "cache": "force-cache",
+                      "height": 600,
+                      "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+                      "width": 500,
+                    },
+                  ]
+                }
                 style={
                   Object {
                     "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
+                    "opacity": 0,
+                    "overflow": "hidden",
+                    "resizeMode": "cover",
                     "width": "100%",
                   }
                 }
@@ -558,12 +628,31 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                 }
               }
             >
-              <View
-                forceRatio={1}
+              <RCTImageView
+                customTheme={null}
+                disabled={false}
+                maxAspectRatio={1}
+                minAspectRatio={1}
+                onLoad={[Function]}
+                resizeMode="cover"
+                source={
+                  Array [
+                    Object {
+                      "__typename": "ImageMediaSource",
+                      "cache": "force-cache",
+                      "height": 600,
+                      "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+                      "width": 500,
+                    },
+                  ]
+                }
                 style={
                   Object {
                     "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
+                    "opacity": 0,
+                    "overflow": "hidden",
+                    "resizeMode": "cover",
                     "width": "100%",
                   }
                 }
@@ -736,12 +825,31 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                 }
               }
             >
-              <View
-                forceRatio={1}
+              <RCTImageView
+                customTheme={null}
+                disabled={false}
+                maxAspectRatio={1}
+                minAspectRatio={1}
+                onLoad={[Function]}
+                resizeMode="cover"
+                source={
+                  Array [
+                    Object {
+                      "__typename": "ImageMediaSource",
+                      "cache": "force-cache",
+                      "height": 600,
+                      "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
+                      "width": 500,
+                    },
+                  ]
+                }
                 style={
                   Object {
                     "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
+                    "opacity": 0,
+                    "overflow": "hidden",
+                    "resizeMode": "cover",
                     "width": "100%",
                   }
                 }

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
@@ -265,17 +265,19 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
                     }
                   }
                 >
-                  <Image
+                  <RCTImageView
                     hasTitleAndSummary={false}
                     maxAspectRatio={1.5}
                     minAspectRatio={1.5}
                     onLoad={[Function]}
+                    resizeMode="cover"
                     source={Array []}
                     style={
                       Object {
                         "aspectRatio": 1,
                         "backgroundColor": "#A5A5A5",
                         "opacity": 0,
+                        "overflow": "hidden",
                         "resizeMode": "cover",
                         "width": "100%",
                       }
@@ -416,17 +418,19 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
                     }
                   }
                 >
-                  <Image
+                  <RCTImageView
                     hasTitleAndSummary={false}
                     maxAspectRatio={1.5}
                     minAspectRatio={1.5}
                     onLoad={[Function]}
+                    resizeMode="cover"
                     source={Array []}
                     style={
                       Object {
                         "aspectRatio": 1,
                         "backgroundColor": "#A5A5A5",
                         "opacity": 0,
+                        "overflow": "hidden",
                         "resizeMode": "cover",
                         "width": "100%",
                       }
@@ -745,17 +749,19 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
                     }
                   }
                 >
-                  <Image
+                  <RCTImageView
                     hasTitleAndSummary={false}
                     maxAspectRatio={1.5}
                     minAspectRatio={1.5}
                     onLoad={[Function]}
+                    resizeMode="cover"
                     source={Array []}
                     style={
                       Object {
                         "aspectRatio": 1,
                         "backgroundColor": "#A5A5A5",
                         "opacity": 0,
+                        "overflow": "hidden",
                         "resizeMode": "cover",
                         "width": "100%",
                       }
@@ -896,17 +902,19 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
                     }
                   }
                 >
-                  <Image
+                  <RCTImageView
                     hasTitleAndSummary={false}
                     maxAspectRatio={1.5}
                     minAspectRatio={1.5}
                     onLoad={[Function]}
+                    resizeMode="cover"
                     source={Array []}
                     style={
                       Object {
                         "aspectRatio": 1,
                         "backgroundColor": "#A5A5A5",
                         "opacity": 0,
+                        "overflow": "hidden",
                         "resizeMode": "cover",
                         "width": "100%",
                       }

--- a/packages/apollos-ui-connected/src/MediaControlsConnected/PlayButtonConnected/__snapshots__/PlayButton.tests.js.snap
+++ b/packages/apollos-ui-connected/src/MediaControlsConnected/PlayButtonConnected/__snapshots__/PlayButton.tests.js.snap
@@ -60,16 +60,17 @@ exports[`PlayButton should render 1`] = `
           }
         }
       >
-        <Image
+        <RCTImageView
           onLoad={[Function]}
+          resizeMode="cover"
           source={
             Array [
               Object {
                 "__typename": "ImageMediaSource",
                 "cache": "force-cache",
-                "height": 240,
+                "height": 600,
                 "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,q_auto:eco,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dfe44d493-b69f-4721-83f7-7942c4f99125",
-                "width": 320,
+                "width": 500,
               },
             ]
           }
@@ -79,6 +80,7 @@ exports[`PlayButton should render 1`] = `
               "bottom": 0,
               "left": 0,
               "opacity": 0,
+              "overflow": "hidden",
               "position": "absolute",
               "right": 0,
               "top": 0,
@@ -324,16 +326,17 @@ exports[`PlayButton should render with custom play icon 1`] = `
           }
         }
       >
-        <Image
+        <RCTImageView
           onLoad={[Function]}
+          resizeMode="cover"
           source={
             Array [
               Object {
                 "__typename": "ImageMediaSource",
                 "cache": "force-cache",
-                "height": 240,
+                "height": 600,
                 "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,q_auto:eco,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dfe44d493-b69f-4721-83f7-7942c4f99125",
-                "width": 320,
+                "width": 500,
               },
             ]
           }
@@ -343,6 +346,7 @@ exports[`PlayButton should render with custom play icon 1`] = `
               "bottom": 0,
               "left": 0,
               "opacity": 1,
+              "overflow": "hidden",
               "position": "absolute",
               "right": 0,
               "top": 0,
@@ -588,16 +592,17 @@ exports[`PlayButton should render with custom title 1`] = `
           }
         }
       >
-        <Image
+        <RCTImageView
           onLoad={[Function]}
+          resizeMode="cover"
           source={
             Array [
               Object {
                 "__typename": "ImageMediaSource",
                 "cache": "force-cache",
-                "height": 240,
+                "height": 600,
                 "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,q_auto:eco,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dfe44d493-b69f-4721-83f7-7942c4f99125",
-                "width": 320,
+                "width": 500,
               },
             ]
           }
@@ -607,6 +612,7 @@ exports[`PlayButton should render with custom title 1`] = `
               "bottom": 0,
               "left": 0,
               "opacity": 1,
+              "overflow": "hidden",
               "position": "absolute",
               "right": 0,
               "top": 0,

--- a/packages/apollos-ui-connected/src/SearchCardConnected/__snapshots__/SearchCardConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/SearchCardConnected/__snapshots__/SearchCardConnected.tests.js.snap
@@ -49,11 +49,12 @@ exports[`The SearchCardConnected component should render 1`] = `
           }
         }
       >
-        <Image
+        <RCTImageView
           customTheme={null}
           maxAspectRatio={1.2}
           minAspectRatio={0.75}
           onLoad={[Function]}
+          resizeMode="cover"
           source={
             Array [
               Object {
@@ -74,6 +75,7 @@ exports[`The SearchCardConnected component should render 1`] = `
             Object {
               "backgroundColor": "#A5A5A5",
               "opacity": 0,
+              "overflow": "hidden",
               "resizeMode": "cover",
               "width": "100%",
             }

--- a/packages/apollos-ui-connected/src/UserAvatarConnected/UserAvatarConnected.tests.js
+++ b/packages/apollos-ui-connected/src/UserAvatarConnected/UserAvatarConnected.tests.js
@@ -20,7 +20,8 @@ describe('UserAvatarConnected component', () => {
               __typename: 'Person',
               id: 'Person:123',
               photo: {
-                uri: 'https://www.placecage.com/300/300',
+                uri:
+                  'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2',
                 __typename: 'ImageMedia',
               },
             },
@@ -34,7 +35,6 @@ describe('UserAvatarConnected component', () => {
         <UserAvatarConnected navigation={navigation} />
       </Providers>
     );
-
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/apollos-ui-connected/src/UserAvatarConnected/UserAvatarConnected.tests.js
+++ b/packages/apollos-ui-connected/src/UserAvatarConnected/UserAvatarConnected.tests.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-import wait from 'waait';
+import { Providers, renderWithApolloData } from '../utils/testUtils';
 
-import { Providers } from '../utils/testUtils';
 import GET_USER_PHOTO from './getUserPhoto';
 
 import UserAvatarConnected from '.';
@@ -31,12 +29,12 @@ describe('UserAvatarConnected component', () => {
       },
     };
     const navigation = { navigate: jest.fn(), getParam: jest.fn() };
-    const tree = renderer.create(
+    const tree = await renderWithApolloData(
       <Providers mocks={[mock]}>
         <UserAvatarConnected navigation={navigation} />
       </Providers>
     );
-    await wait(0); // wait for response from graphql
+
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/apollos-ui-connected/src/UserAvatarConnected/__snapshots__/UserAvatarConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/UserAvatarConnected/__snapshots__/UserAvatarConnected.tests.js.snap
@@ -12,52 +12,34 @@ exports[`UserAvatarConnected component renders UserAvatarConnected 1`] = `
   }
   themeSize={40}
 >
-  <View
-    animate={null}
-    customAnimate={null}
-    onReady={false}
+  <Image
+    onLoad={[Function]}
+    source={
+      Array [
+        Object {
+          "__typename": "ImageMedia",
+          "cache": "force-cache",
+          "height": 240,
+          "uri": "https://www.placecage.com/300/300",
+          "width": 320,
+        },
+      ]
+    }
     style={
       Object {
-        "aspectRatio": 1,
         "backgroundColor": "#A5A5A5",
         "borderRadius": 20,
         "bottom": 0,
         "height": "100%",
         "left": 0,
+        "opacity": 0,
         "position": "absolute",
         "right": 0,
         "top": 0,
         "width": "100%",
       }
     }
-  >
-    <Image
-      onLoad={[Function]}
-      source={
-        Array [
-          Object {
-            "__typename": "ImageMedia",
-            "cache": "force-cache",
-            "uri": "https://www.placecage.com/300/300",
-          },
-        ]
-      }
-      style={
-        Object {
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 20,
-          "bottom": 0,
-          "height": "100%",
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "width": "100%",
-        }
-      }
-      themeSize={40}
-    />
-  </View>
+    themeSize={40}
+  />
 </View>
 `;

--- a/packages/apollos-ui-connected/src/UserAvatarConnected/__snapshots__/UserAvatarConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/UserAvatarConnected/__snapshots__/UserAvatarConnected.tests.js.snap
@@ -21,7 +21,7 @@ exports[`UserAvatarConnected component renders UserAvatarConnected 1`] = `
           "__typename": "ImageMedia",
           "cache": "force-cache",
           "height": 600,
-          "uri": "https://www.placecage.com/300/300",
+          "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3D31af1a61-360c-4b1e-8e62-45517c06a9a2",
           "width": 500,
         },
       ]

--- a/packages/apollos-ui-connected/src/UserAvatarConnected/__snapshots__/UserAvatarConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/UserAvatarConnected/__snapshots__/UserAvatarConnected.tests.js.snap
@@ -12,16 +12,17 @@ exports[`UserAvatarConnected component renders UserAvatarConnected 1`] = `
   }
   themeSize={40}
 >
-  <Image
+  <RCTImageView
     onLoad={[Function]}
+    resizeMode="cover"
     source={
       Array [
         Object {
           "__typename": "ImageMedia",
           "cache": "force-cache",
-          "height": 240,
+          "height": 600,
           "uri": "https://www.placecage.com/300/300",
-          "width": 320,
+          "width": 500,
         },
       ]
     }
@@ -33,6 +34,7 @@ exports[`UserAvatarConnected component renders UserAvatarConnected 1`] = `
         "height": "100%",
         "left": 0,
         "opacity": 0,
+        "overflow": "hidden",
         "position": "absolute",
         "right": 0,
         "top": 0,


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This PR stabilizes tests in `ui-connected` by mocking `Image.getSize` and `Animated.timing`. Hopefully this should reduce the amount of erratic failures that I am seeing in travis and locally. 

### What design trade-offs/decisions were made?

### How do I test this PR?

Run the tests locally, make sure they don't fail for you.

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
