### PR TITLE
Adds Auth to External Browser

### DIFF
--- a/packages/apollos-ui-connected/src/RockAuthedWebBrowser/RockAuthedWebBrowser.js
+++ b/packages/apollos-ui-connected/src/RockAuthedWebBrowser/RockAuthedWebBrowser.js
@@ -46,7 +46,11 @@ const RockAuthedInAppBrowser = {
           .split(':')[0]
           .toLowerCase()
       );
-      if (isValidUrl && (await InAppBrowser.isAvailable())) {
+      if (
+        !options.externalBrowser &&
+        isValidUrl &&
+        (await InAppBrowser.isAvailable())
+      ) {
         InAppBrowser.open(url.toString(), {
           headers,
           ...options,

--- a/packages/apolloschurchapp/src/testing-control-panel/index.js
+++ b/packages/apolloschurchapp/src/testing-control-panel/index.js
@@ -41,6 +41,17 @@ export default class TestingControlPanel extends PureComponent {
                 cellText={`Open InAppBrowser With Rock Token`}
               />
               <TouchableCell
+                handlePress={() =>
+                  openUrl(
+                    'https://apollosrock.newspring.cc',
+                    { externalBrowser: true },
+                    { useRockToken: true }
+                  )
+                }
+                iconName="share"
+                cellText={`Open Safari With Rock Token`}
+              />
+              <TouchableCell
                 handlePress={() => openUrl('mailto:fake@apollosproject.com')}
                 iconName="share"
                 cellText={`Open Email link`}


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-02-20 at 11 48 03 AM](https://user-images.githubusercontent.com/2659478/74958584-2b6f2600-53d7-11ea-922e-74b692041c0a.png)


### What does this PR do, or why is it needed?

This gives us the ability to authenticate to Rock while using Safari or another external browser.

### What design trade-offs/decisions were made?

None.

### How do I test this PR?

There's a button in the testing panel.

### What automated tests did you write?

None.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._