### PR TITLE
Fixes Horizontal Content Series Connected Crash when Loading

### DIFF
--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.js
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.js
@@ -98,6 +98,7 @@ class HorizontalContentSeriesFeedConnected extends Component {
           index,
         })}
         onEndReached={() =>
+          !loading &&
           fetchMore({
             query: GET_CONTENT_SERIES,
             variables: { cursor, itemId: this.props.contentId },


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Don't try and run the onEndReached method when loading. If you don't have content (or the content is still loading) you get one of two different Red Screens. 

This is only an issue now, because previously this component wouldn't render at all when it was loading (rather than the correct, current behavior, of rendering a loading state). 

### What design trade-offs/decisions were made?

### How do I test this PR?

I tested this fix in Willow. You'll need to make sure you don't have any content cached in your app, then tap on items with children (Psalm 119 items are a good item on the home feed). 

Before this update, you'll get a crash about 70% of the time. You won't be able to reproduce the crash with the same item (because the item will no longer ever be loading, once loaded once) 

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
