### PR TITLE
Fixes being forced through register after you have already registered

### DIFF
--- a/packages/apollos-ui-auth/src/LoginProvider.js
+++ b/packages/apollos-ui-auth/src/LoginProvider.js
@@ -134,6 +134,7 @@ class LoginProvider extends React.Component {
     } = await client.query({
       query: GET_USER_EXISTS,
       variables: { identity },
+      fetchPolicy: 'network-only',
     });
 
     const newUser = userExists === 'NONE';


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

We successfully made sure this query wasn't cached in the schema, but we still need to make sure the client doesn't pull the data from it's own internal cache.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Register with a new email address.
2. Logout
3. Try to login with the email address from above. You should be able to login, instead of being forced through register again. 

### What automated tests did you write?
n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
