### PR TITLE
Adds capability to styled overrides; they can now be a function of component props

### DIFF
--- a/packages/apollos-ui-kit/src/styled/__snapshots__/styled.tests.js.snap
+++ b/packages/apollos-ui-kit/src/styled/__snapshots__/styled.tests.js.snap
@@ -10,6 +10,26 @@ exports[`the styled HOC allows a theme to supply overrides 1`] = `
 />
 `;
 
+exports[`the styled HOC allows a theme to supply overrides that depend on props 1`] = `
+Array [
+  <View
+    active={true}
+    style={
+      Object {
+        "backgroundColor": "green",
+      }
+    }
+  />,
+  <View
+    style={
+      Object {
+        "backgroundColor": "blue",
+      }
+    }
+  />,
+]
+`;
+
 exports[`the styled HOC passes style literal to the base component 1`] = `
 <View
   style={

--- a/packages/apollos-ui-kit/src/styled/index.js
+++ b/packages/apollos-ui-kit/src/styled/index.js
@@ -59,7 +59,15 @@ const styled = (styleInput, fqn) =>
           theme,
         });
 
-        const themeOverrides = fqn ? get(theme, `overrides['${fqn}']`, {}) : {};
+        const themeOverridesValue = fqn
+          ? get(theme, `overrides['${fqn}']`, {})
+          : {};
+
+        const themeOverrides =
+          typeof themeOverridesValue === 'function'
+            ? themeOverridesValue(ownProps)
+            : themeOverridesValue;
+
         const { style: ownPropsStyle = {} } = ownProps;
 
         style = mergeStyles(style, themeOverrides, ownPropsStyle);

--- a/packages/apollos-ui-kit/src/styled/styled.tests.js
+++ b/packages/apollos-ui-kit/src/styled/styled.tests.js
@@ -54,4 +54,22 @@ describe('the styled HOC', () => {
     );
     expect(tree).toMatchSnapshot();
   });
+
+  it('allows a theme to supply overrides that depend on props', () => {
+    const StyledView = styled(() => ({ backgroundColor: 'red' }), 'StyledView')(
+      View
+    );
+    const overrides = {
+      StyledView: () => ({ active }) => ({
+        backgroundColor: active ? 'green' : 'blue',
+      }),
+    };
+    const tree = renderer.create(
+      <Providers themeInput={{ overrides }}>
+        <StyledView active />
+        <StyledView />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

I wanted style overrides to be able to look at the component's props. It will make styling some crucial components (like radio buttons and other interactive styled elements) way easier. 

### What design trade-offs/decisions were made?

We now have functions stored in the theme, but we already have them anyway! So I think we're okay. 

### How do I test this PR?

Write yourself some overrides :) or look at the test I wrote.

### What automated tests did you write?

Test demonstrating new functionality.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
