### PR TITLE
Adds props handle to onboarding button

### DIFF
--- a/packages/apollos-ui-onboarding/src/Slide/Slide.js
+++ b/packages/apollos-ui-onboarding/src/Slide/Slide.js
@@ -76,6 +76,7 @@ const Slide = memo(
     onPressSecondary,
     primaryNavText,
     primaryNavIcon,
+    primaryButtonProps,
     secondaryNavText,
     isLoading,
     pressPrimaryEventName,
@@ -98,6 +99,7 @@ const Slide = memo(
                 trackEventName={pressPrimaryEventName}
                 onPress={onPressPrimary}
                 loading={isLoading}
+                {...primaryButtonProps}
               >
                 <>
                   <H5>{primaryNavText}</H5>
@@ -135,6 +137,7 @@ Slide.propTypes = {
   primaryNavIcon: PropTypes.string, // optional custom icon name or empty string for no icon at all
   secondaryNavText: PropTypes.string, // text link
   isLoading: PropTypes.bool,
+  primaryButtonProps: PropTypes.shape({}), // can be anything
 };
 
 Slide.defaultProps = {

--- a/packages/apollos-ui-onboarding/src/Slide/Slide.tests.js
+++ b/packages/apollos-ui-onboarding/src/Slide/Slide.tests.js
@@ -108,4 +108,17 @@ describe('The Onboarding Slide component', () => {
     );
     expect(tree).toMatchSnapshot();
   });
+  it('should add a test ID', () => {
+    const tree = renderer.create(
+      <Providers>
+        <Slide
+          onPressPrimary={jest.fn()}
+          primaryButtonProps={{ testID: 'primary-button' }}
+        >
+          <Text>Boom</Text>
+        </Slide>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/apollos-ui-onboarding/src/Slide/__snapshots__/Slide.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/Slide/__snapshots__/Slide.tests.js.snap
@@ -1,5 +1,228 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The Onboarding Slide component should add a test ID 1`] = `
+Array [
+  <RCTScrollView
+    contentContainerStyle={
+      Object {
+        "minHeight": "100%",
+      }
+    }
+    overScrollMode="auto"
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View>
+      <Text>
+        Boom
+      </Text>
+    </View>
+  </RCTScrollView>,
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "bottom": 0,
+        "flexDirection": "row-reverse",
+        "justifyContent": "space-between",
+        "left": 0,
+        "marginVertical": 8,
+        "paddingHorizontal": 16,
+        "paddingVertical": 0,
+        "position": "absolute",
+        "right": 0,
+      }
+    }
+    vertical={false}
+  >
+    <RCTSafeAreaView
+      emulateUnlessSupported={true}
+      forceInset={
+        Object {
+          "bottom": "always",
+          "top": "never",
+        }
+      }
+    >
+      <View
+        accessible={true}
+        clickable={true}
+        isTVSelectable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID="primary-button"
+      >
+        <View
+          bordered={false}
+          disabled={false}
+          pill={true}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#00676D",
+              "borderColor": "#00676D",
+              "borderRadius": 48,
+              "borderWidth": 2,
+              "elevation": 2,
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "opacity": 1,
+              "overflow": "hidden",
+              "paddingHorizontal": 16,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#FFFFFF",
+                "fontFamily": "InterUI-Medium",
+                "fontSize": 14,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Next
+          </Text>
+          <RNSVGSvgView
+            align="xMidYMid"
+            bbHeight={20}
+            bbWidth={20}
+            height={20}
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                Object {
+                  "marginLeft": 8,
+                  "marginRight": -8,
+                },
+                null,
+                Object {
+                  "flex": 0,
+                  "height": 20,
+                  "width": 20,
+                },
+              ]
+            }
+            vbHeight={24}
+            vbWidth={24}
+            width={20}
+          >
+            <RNSVGGroup
+              fill={
+                Array [
+                  0,
+                  4278190080,
+                ]
+              }
+              fillOpacity={1}
+              fillRule={1}
+              font={Object {}}
+              matrix={
+                Array [
+                  1,
+                  0,
+                  0,
+                  1,
+                  0,
+                  0,
+                ]
+              }
+              opacity={1}
+              originX={0}
+              originY={0}
+              propList={Array []}
+              rotation={0}
+              scaleX={1}
+              scaleY={1}
+              skewX={0}
+              skewY={0}
+              stroke={null}
+              strokeDasharray={null}
+              strokeDashoffset={null}
+              strokeLinecap={0}
+              strokeLinejoin={0}
+              strokeMiterlimit={4}
+              strokeOpacity={1}
+              strokeWidth={1}
+              vectorEffect={0}
+              x={0}
+              y={0}
+            >
+              <RNSVGPath
+                d="M9.65 21L8 20.1l7.72-8.1L8 3.9 9.65 3l8.16 8.54c.27.28.27.64 0 .92L9.67 21z"
+                fill={
+                  Array [
+                    0,
+                    4294967295,
+                  ]
+                }
+                fillOpacity={1}
+                fillRule={1}
+                matrix={
+                  Array [
+                    1,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                  ]
+                }
+                opacity={1}
+                originX={0}
+                originY={0}
+                propList={
+                  Array [
+                    "fill",
+                  ]
+                }
+                rotation={0}
+                scaleX={1}
+                scaleY={1}
+                skewX={0}
+                skewY={0}
+                stroke={null}
+                strokeDasharray={null}
+                strokeDashoffset={null}
+                strokeLinecap={0}
+                strokeLinejoin={0}
+                strokeMiterlimit={4}
+                strokeOpacity={1}
+                strokeWidth={1}
+                vectorEffect={0}
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+      </View>
+    </RCTSafeAreaView>
+  </View>,
+]
+`;
+
 exports[`The Onboarding Slide component should render a loading indicator 1`] = `
 Array [
   <RCTScrollView


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This adds the ability to pass arbritrary button props to the primary buttons in onboarding. The specific use case I have in mind is to allow integration testing by passing the `testID` prop.

### What design trade-offs/decisions were made?

Exposes the button to be customized further.

### How do I test this PR?

Pass a button prop into `<Slide>` from the app package and make sure it takes effect.

### What automated tests did you write?

Snap coverage.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._