### PR TITLE
Decrease the cache time for the livestreams query

### DIFF
--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -526,7 +526,7 @@ export const liveSchema = gql`
   extend type Query {
     liveStream: LiveStream
       @deprecated(reason: "Use liveStreams, there may be multiple.")
-    liveStreams: [LiveStream]
+    liveStreams: [LiveStream] @cacheControl(maxAge: 10)
   }
 
   extend type WeekendContentItem {

--- a/packages/apollos-ui-connected/src/ContentCardConnected/ContentCardConnected.js
+++ b/packages/apollos-ui-connected/src/ContentCardConnected/ContentCardConnected.js
@@ -24,7 +24,7 @@ const ContentCardConnected = memo(
 
               const coverImage = get(node, 'coverImage.sources', undefined);
               const hasMedia = !!get(node, 'videos.[0].sources[0]', null);
-              const isLive = liveStream && liveStream.isLive;
+              const isLive = !!(liveStream && liveStream.isLive);
               const labelText = get(node, 'parentChannel.name', '');
 
               return (

--- a/packages/apollos-ui-connected/src/ContentCardConnected/ContentCardConnected.js
+++ b/packages/apollos-ui-connected/src/ContentCardConnected/ContentCardConnected.js
@@ -24,7 +24,7 @@ const ContentCardConnected = memo(
 
               const coverImage = get(node, 'coverImage.sources', undefined);
               const hasMedia = !!get(node, 'videos.[0].sources[0]', null);
-              const isLive = !!liveStream;
+              const isLive = liveStream && liveStream.isLive;
               const labelText = get(node, 'parentChannel.name', '');
 
               return (


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Didn't realize this was GraphQL's behavior, but it makes sense 🤷‍♂ If a field isn't included in a response, then it's `maxAge` value is not respected for the returned result. 

## Before

<img width="1632" alt="Screen Shot 2020-03-16 at 8 20 11 AM" src="https://user-images.githubusercontent.com/1637694/76758734-b508de00-6760-11ea-9109-c7333c6e8f27.png">
<img width="1571" alt="Screen Shot 2020-03-16 at 8 21 12 AM" src="https://user-images.githubusercontent.com/1637694/76758736-b508de00-6760-11ea-9df0-204c35100306.png">

## After

<img width="1375" alt="Screen Shot 2020-03-16 at 8 26 18 AM" src="https://user-images.githubusercontent.com/1637694/76758741-b6d2a180-6760-11ea-9d4a-d8f5b7b6a81d.png">

### What design trade-offs/decisions were made?

Long term there's a better fix for this PR, but we'll need to be clever about it because it will cause breaking changes. 

1. Setup the `LiveStreams` query so that it _always_ returns content items, even if the `liveStream.isLive` is `false. 
2. Change the client LiveStream provider so that it uses the `true/falseness` of `LiveStream.isLive` rather than the presence of the item in the array. **I'll include that fix in this PR**. 

If we do step 1, without first deploying step 2, old versions of the app will display content as live perpetually. 

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
