### PR TITLE
Safer handling of getting horizontal content item fetch more results

### DIFF
--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.js
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.js
@@ -106,7 +106,8 @@ class HorizontalContentSeriesFeedConnected extends Component {
               const connection = isParent
                 ? 'childContentItemsConnection'
                 : 'siblingContentItemsConnection';
-              const newEdges = get(fetchMoreResult, `node.${connection}.edges`) || []);
+              const newEdges =
+                get(fetchMoreResult, `node.${connection}.edges`) || [];
 
               return {
                 node: {

--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.js
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/HorizontalContentSeriesFeedConnected.js
@@ -106,7 +106,7 @@ class HorizontalContentSeriesFeedConnected extends Component {
               const connection = isParent
                 ? 'childContentItemsConnection'
                 : 'siblingContentItemsConnection';
-              const newEdges = get(fetchMoreResult.node, connection, []).edges;
+              const newEdges = get(fetchMoreResult, `node.${connection}.edges`) || []);
 
               return {
                 node: {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Have been getting off-and-on errors navigating content and content children on The Porch App. Such as:

![Screen Shot 2020-03-16 at 2 40 24 PM](https://user-images.githubusercontent.com/103927/76793957-126a5280-6794-11ea-98c5-78e8769d385c.png)

and 

![Screen Shot 2020-03-16 at 2 41 06 PM](https://user-images.githubusercontent.com/103927/76794004-2d3cc700-6794-11ea-9847-291c44adefa9.png)

Looking at network stacks, it appears that all queries were successful. I am unsure why `null` is being returned in this scenario yet, but it seems like something the UI should handle without throwing errors. Thoughts?

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
