### PR TITLE
Adds export for horizontalContentCardComponentMapper to ui-connected package

### DIFF
--- a/packages/apollos-ui-connected/src/HorizontalContentCardConnected/HorizontalContentCardConnected.js
+++ b/packages/apollos-ui-connected/src/HorizontalContentCardConnected/HorizontalContentCardConnected.js
@@ -1,0 +1,29 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+
+import ContentCardConnected from '../ContentCardConnected';
+
+import horizontalContentCardComponentMapper from './horizontalContentCardComponentMapper';
+
+const HorizontalContentCardConnected = memo(
+  ({ Component, isLoading, ...otherProps }) => (
+    <ContentCardConnected
+      Component={Component}
+      isLoading={isLoading}
+      {...otherProps}
+    />
+  )
+);
+
+HorizontalContentCardConnected.propTypes = {
+  Component: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+HorizontalContentCardConnected.defaultProps = {
+  Component: horizontalContentCardComponentMapper,
+};
+
+HorizontalContentCardConnected.displayName = 'HorizontalContentCardConnected';
+
+export default HorizontalContentCardConnected;

--- a/packages/apollos-ui-connected/src/HorizontalContentCardConnected/index.js
+++ b/packages/apollos-ui-connected/src/HorizontalContentCardConnected/index.js
@@ -1,29 +1,5 @@
-import React, { memo } from 'react';
-import PropTypes from 'prop-types';
+import HorizontalContentCardConnected from './HorizontalContentCardConnected';
 
-import ContentCardConnected from '../ContentCardConnected';
-
-import horizontalContentCardComponentMapper from './horizontalContentCardComponentMapper';
-
-const HorizontalContentCardConnected = memo(
-  ({ Component, isLoading, ...otherProps }) => (
-    <ContentCardConnected
-      Component={Component}
-      isLoading={isLoading}
-      {...otherProps}
-    />
-  )
-);
-
-HorizontalContentCardConnected.propTypes = {
-  Component: PropTypes.func,
-  isLoading: PropTypes.bool,
-};
-
-HorizontalContentCardConnected.defaultProps = {
-  Component: horizontalContentCardComponentMapper,
-};
-
-HorizontalContentCardConnected.displayName = 'HorizontalContentCardConnected';
+export horizontalContentCardComponentMapper from './horizontalContentCardComponentMapper';
 
 export default HorizontalContentCardConnected;

--- a/packages/apollos-ui-connected/src/index.js
+++ b/packages/apollos-ui-connected/src/index.js
@@ -9,7 +9,9 @@ export ContentSingleFeaturesConnected, {
   ScriptureFeature,
   TextFeature,
 } from './ContentSingleFeaturesConnected';
-export HorizontalContentCardConnected from './HorizontalContentCardConnected';
+export HorizontalContentCardConnected, {
+  horizontalContentCardComponentMapper,
+} from './HorizontalContentCardConnected';
 export HorizontalContentSeriesFeedConnected, {
   GET_CONTENT_SERIES,
 } from './HorizontalContentSeriesFeedConnected';


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
Adds export for horizontalContentCardComponentMapper to ui-connected package. We normally do this for all of our connected components so that the pieces that make up our connected components can be used to create new connected components. Not sure why we didn't do it to begin with but here it is now.

This PR is blocking https://github.com/ApollosProject/apollos-templates/pull/24
### What design trade-offs/decisions were made?
N/A
### How do I test this PR?
N/A
### What automated tests did you write?
N/A
## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
