### PR TITLE
Updated Shadow Value

### DIFF
--- a/packages/apollos-ui-auth/src/Password/__snapshots__/EmailEntryConnected.tests.js.snap
+++ b/packages/apollos-ui-auth/src/Password/__snapshots__/EmailEntryConnected.tests.js.snap
@@ -110,13 +110,13 @@ exports[`ui-auth/Password/EmailEntryConnected should render 1`] = `
                 "borderRadius": 16,
                 "marginHorizontal": 0,
                 "marginVertical": 0,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -264,13 +264,13 @@ exports[`ui-auth/Password/EmailEntryConnected should render 1`] = `
                     "marginHorizontal": 0,
                     "marginVertical": 0,
                     "paddingTop": 0,
-                    "shadowColor": "rgba(165, 165, 165, 0.6)",
+                    "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                     "shadowOffset": Object {
-                      "height": 1,
+                      "height": 2,
                       "width": 0,
                     },
                     "shadowOpacity": 0,
-                    "shadowRadius": 6,
+                    "shadowRadius": 8,
                   }
                 }
               >

--- a/packages/apollos-ui-auth/src/SMS/__snapshots__/PhoneEntryConnected.tests.js.snap
+++ b/packages/apollos-ui-auth/src/SMS/__snapshots__/PhoneEntryConnected.tests.js.snap
@@ -110,13 +110,13 @@ exports[`ui-auth/SMS/PhoneEntryConnected should render 1`] = `
                 "borderRadius": 16,
                 "marginHorizontal": 0,
                 "marginVertical": 0,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -264,13 +264,13 @@ exports[`ui-auth/SMS/PhoneEntryConnected should render 1`] = `
                     "marginHorizontal": 0,
                     "marginVertical": 0,
                     "paddingTop": 0,
-                    "shadowColor": "rgba(165, 165, 165, 0.6)",
+                    "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                     "shadowOffset": Object {
-                      "height": 1,
+                      "height": 2,
                       "width": 0,
                     },
                     "shadowOpacity": 0,
-                    "shadowRadius": 6,
+                    "shadowRadius": 8,
                   }
                 }
               >

--- a/packages/apollos-ui-connected/src/ActionListFeature/__snapshots__/ActionListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ActionListFeature/__snapshots__/ActionListFeature.tests.js.snap
@@ -8,13 +8,13 @@ exports[`The ActionListFeatures component should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -39,7 +39,7 @@ exports[`The ActionListFeatures component should render 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -122,7 +122,7 @@ exports[`The ActionListFeatures component should render 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -237,7 +237,7 @@ exports[`The ActionListFeatures component should render 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -352,7 +352,7 @@ exports[`The ActionListFeatures component should render 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -467,7 +467,7 @@ exports[`The ActionListFeatures component should render 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -520,13 +520,13 @@ exports[`The ActionListFeatures component should render a button for onPressActi
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -551,7 +551,7 @@ exports[`The ActionListFeatures component should render a button for onPressActi
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -634,7 +634,7 @@ exports[`The ActionListFeatures component should render a button for onPressActi
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -749,7 +749,7 @@ exports[`The ActionListFeatures component should render a button for onPressActi
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -864,7 +864,7 @@ exports[`The ActionListFeatures component should render a button for onPressActi
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -979,7 +979,7 @@ exports[`The ActionListFeatures component should render a button for onPressActi
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1098,13 +1098,13 @@ exports[`The ActionListFeatures component should render a loading state for isLo
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1154,7 +1154,7 @@ exports[`The ActionListFeatures component should render a loading state for isLo
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -1237,7 +1237,7 @@ exports[`The ActionListFeatures component should render a loading state for isLo
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1335,7 +1335,7 @@ exports[`The ActionListFeatures component should render a loading state for isLo
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1433,7 +1433,7 @@ exports[`The ActionListFeatures component should render a loading state for isLo
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1531,7 +1531,7 @@ exports[`The ActionListFeatures component should render a loading state for isLo
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1567,13 +1567,13 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1611,7 +1611,7 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -1694,7 +1694,7 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1809,7 +1809,7 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1924,7 +1924,7 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2039,7 +2039,7 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2092,13 +2092,13 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -2137,7 +2137,7 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -2220,7 +2220,7 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2335,7 +2335,7 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2450,7 +2450,7 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2565,7 +2565,7 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",

--- a/packages/apollos-ui-connected/src/CampaignItemListFeature/__snapshots__/CampaignItemListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/CampaignItemListFeature/__snapshots__/CampaignItemListFeature.tests.js.snap
@@ -103,13 +103,13 @@ exports[`The CampaignItemListFeature component should render 1`] = `
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -597,13 +597,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -803,13 +803,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1009,13 +1009,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1215,13 +1215,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1421,13 +1421,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1627,13 +1627,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1833,13 +1833,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2039,13 +2039,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2245,13 +2245,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2451,13 +2451,13 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2757,13 +2757,13 @@ exports[`The CampaignItemListFeature component should render a section title 1`]
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -3055,13 +3055,13 @@ exports[`The CampaignItemListFeature component should render with a subtitle 1`]
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "transparent",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >

--- a/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/ContentSingleFeatures/__snapshots__/ContentSingleFeatures.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/ContentSingleFeatures/__snapshots__/ContentSingleFeatures.tests.js.snap
@@ -42,13 +42,13 @@ exports[`ContentSingleFeatures should render 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -239,13 +239,13 @@ exports[`ContentSingleFeatures should render 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -535,13 +535,13 @@ exports[`ContentSingleFeatures should render 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -865,13 +865,13 @@ exports[`ContentSingleFeatures should render a loading state 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -1062,13 +1062,13 @@ exports[`ContentSingleFeatures should render a loading state 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -1307,13 +1307,13 @@ exports[`ContentSingleFeatures should render a loading state 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -1590,13 +1590,13 @@ exports[`ContentSingleFeatures should take a custom title 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -1787,13 +1787,13 @@ exports[`ContentSingleFeatures should take a custom title 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -2083,13 +2083,13 @@ exports[`ContentSingleFeatures should take a custom title 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >

--- a/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/__snapshots__/ContentSingleFeaturesConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/__snapshots__/ContentSingleFeaturesConnected.tests.js.snap
@@ -42,13 +42,13 @@ exports[`ContentSingleFeaturesConnected should render 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -239,13 +239,13 @@ exports[`ContentSingleFeaturesConnected should render 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >
@@ -535,13 +535,13 @@ exports[`ContentSingleFeaturesConnected should render 1`] = `
         "borderRadius": 16,
         "marginHorizontal": 16,
         "marginVertical": 12,
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       }
     }
   >

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
@@ -149,13 +149,14 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -512,13 +513,14 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -704,13 +706,14 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -1053,13 +1056,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -1254,13 +1258,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -1455,13 +1460,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -1656,13 +1662,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -1857,13 +1864,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -2194,13 +2202,14 @@ exports[`The HorizontalCardListFeature component should render a section title 1
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -2557,13 +2566,14 @@ exports[`The HorizontalCardListFeature component should render a section title 1
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -2749,13 +2759,14 @@ exports[`The HorizontalCardListFeature component should render a section title 1
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -3082,13 +3093,14 @@ exports[`The HorizontalCardListFeature component should render with a section su
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -3445,13 +3457,14 @@ exports[`The HorizontalCardListFeature component should render with a section su
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -3637,13 +3650,14 @@ exports[`The HorizontalCardListFeature component should render with a section su
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "transparent",
+                "marginBottom": 12,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }

--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
@@ -204,13 +204,13 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
-              "shadowColor": "transparent",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
               "width": 240,
             }
           }
@@ -401,13 +401,13 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
-              "shadowColor": "transparent",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
               "width": 240,
             }
           }
@@ -598,13 +598,13 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
-              "shadowColor": "transparent",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
               "width": 240,
             }
           }
@@ -795,13 +795,13 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
-              "shadowColor": "transparent",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
               "width": 240,
             }
           }

--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
@@ -204,6 +204,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
+              "marginBottom": 12,
               "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
                 "height": 2,
@@ -401,6 +402,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
+              "marginBottom": 12,
               "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
                 "height": 2,
@@ -598,6 +600,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
+              "marginBottom": 12,
               "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
                 "height": 2,
@@ -795,6 +798,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
               "borderRadius": 16,
               "height": 240,
               "margin": 8,
+              "marginBottom": 12,
               "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
                 "height": 2,

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
@@ -223,13 +223,13 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -376,13 +376,13 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -707,13 +707,13 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }
@@ -860,13 +860,13 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 240,
               }
             }

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
@@ -223,6 +223,7 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
+                "marginBottom": 12,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
                   "height": 2,
@@ -376,6 +377,7 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
+                "marginBottom": 12,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
                   "height": 2,
@@ -707,6 +709,7 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
+                "marginBottom": 12,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
                   "height": 2,
@@ -860,6 +863,7 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
                 "borderRadius": 16,
                 "height": 240,
                 "margin": 8,
+                "marginBottom": 12,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
                   "height": 2,

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/__snapshots__/HorizontalLikedContentFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/__snapshots__/HorizontalLikedContentFeedConnected.tests.js.snap
@@ -219,13 +219,13 @@ exports[`HorizontalLikedContentFeedConnected renders a HorizontalLikedContentFee
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -461,13 +461,13 @@ exports[`HorizontalLikedContentFeedConnected renders a HorizontalLikedContentFee
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -680,13 +680,13 @@ exports[`HorizontalLikedContentFeedConnected renders a HorizontalLikedContentFee
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/__snapshots__/HorizontalLikedContentFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/__snapshots__/HorizontalLikedContentFeedConnected.tests.js.snap
@@ -680,6 +680,7 @@ exports[`HorizontalLikedContentFeedConnected renders a HorizontalLikedContentFee
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,

--- a/packages/apollos-ui-connected/src/LikedContentFeedConnected/__snapshots__/LikedContentList.tests.js.snap
+++ b/packages/apollos-ui-connected/src/LikedContentFeedConnected/__snapshots__/LikedContentList.tests.js.snap
@@ -165,13 +165,13 @@ fragment contentCardFragment on ContentItem {
             "borderRadius": 16,
             "marginHorizontal": 16,
             "marginVertical": 12,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >

--- a/packages/apollos-ui-connected/src/MediaControlsConnected/PlayButtonConnected/__snapshots__/PlayButton.tests.js.snap
+++ b/packages/apollos-ui-connected/src/MediaControlsConnected/PlayButtonConnected/__snapshots__/PlayButton.tests.js.snap
@@ -40,13 +40,13 @@ exports[`PlayButton should render 1`] = `
           "height": 80,
           "marginHorizontal": 16,
           "marginVertical": 0,
-          "shadowColor": "rgba(165, 165, 165, 0.6)",
+          "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
-            "height": 1,
+            "height": 2,
             "width": 0,
           },
           "shadowOpacity": 1,
-          "shadowRadius": 6,
+          "shadowRadius": 8,
         }
       }
     >
@@ -306,13 +306,13 @@ exports[`PlayButton should render with custom play icon 1`] = `
           "height": 80,
           "marginHorizontal": 16,
           "marginVertical": 0,
-          "shadowColor": "rgba(165, 165, 165, 0.6)",
+          "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
-            "height": 1,
+            "height": 2,
             "width": 0,
           },
           "shadowOpacity": 1,
-          "shadowRadius": 6,
+          "shadowRadius": 8,
         }
       }
     >
@@ -572,13 +572,13 @@ exports[`PlayButton should render with custom title 1`] = `
           "height": 80,
           "marginHorizontal": 16,
           "marginVertical": 0,
-          "shadowColor": "rgba(165, 165, 165, 0.6)",
+          "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
-            "height": 1,
+            "height": 2,
             "width": 0,
           },
           "shadowOpacity": 1,
-          "shadowRadius": 6,
+          "shadowRadius": 8,
         }
       }
     >

--- a/packages/apollos-ui-connected/src/SearchCardConnected/__snapshots__/SearchCardConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/SearchCardConnected/__snapshots__/SearchCardConnected.tests.js.snap
@@ -9,13 +9,13 @@ exports[`The SearchCardConnected component should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-connected/src/VerticalCardListFeature/__snapshots__/VerticalCardListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeature/__snapshots__/VerticalCardListFeature.tests.js.snap
@@ -102,13 +102,13 @@ exports[`The VerticalCardListFeature component should render 1`] = `
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -575,13 +575,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -760,13 +760,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -945,13 +945,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1130,13 +1130,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1315,13 +1315,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1500,13 +1500,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1685,13 +1685,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -1870,13 +1870,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2055,13 +2055,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2240,13 +2240,13 @@ exports[`The VerticalCardListFeature component should render a loading state for
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2525,13 +2525,13 @@ exports[`The VerticalCardListFeature component should render a section title 1`]
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >
@@ -2802,13 +2802,13 @@ exports[`The VerticalCardListFeature component should render with a subtitle 1`]
                 "borderRadius": 16,
                 "marginHorizontal": 16,
                 "marginVertical": 12,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >

--- a/packages/apollos-ui-kit/src/ActionBar/__snapshots__/ActionBar.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ActionBar/__snapshots__/ActionBar.tests.js.snap
@@ -8,13 +8,13 @@ exports[`the ActionBar component should render children 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/ActionCard/__snapshots__/ActionCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ActionCard/__snapshots__/ActionCard.tests.js.snap
@@ -9,13 +9,13 @@ exports[`the ActionCard component should accept additional Card props 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -62,13 +62,13 @@ exports[`the ActionCard component should render an action 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -439,13 +439,13 @@ exports[`the ActionCard component should render an icon and label 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -641,13 +641,13 @@ exports[`the ActionCard component should render children 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/ActionListCard/ActionListItem/__snapshots__/ActionListItem.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ActionListCard/ActionListItem/__snapshots__/ActionListItem.tests.js.snap
@@ -75,7 +75,7 @@ exports[`ActionListItem should render 1`] = `
       style={
         Object {
           "borderBottomWidth": 0.5,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "flex": 1,
           "height": 68,
           "justifyContent": "center",
@@ -190,7 +190,7 @@ exports[`ActionListItem should render a loading state 1`] = `
       style={
         Object {
           "borderBottomWidth": 0.5,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "flex": 1,
           "height": 68,
           "justifyContent": "center",
@@ -302,7 +302,7 @@ exports[`ActionListItem should render with a label 1`] = `
       style={
         Object {
           "borderBottomWidth": 0.5,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "flex": 1,
           "height": 68,
           "justifyContent": "center",

--- a/packages/apollos-ui-kit/src/ActionListCard/__snapshots__/ActionListCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ActionListCard/__snapshots__/ActionListCard.tests.js.snap
@@ -8,13 +8,13 @@ exports[`ActionListCard should render 5 items 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -39,7 +39,7 @@ exports[`ActionListCard should render 5 items 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -121,7 +121,7 @@ exports[`ActionListCard should render 5 items 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -235,7 +235,7 @@ exports[`ActionListCard should render 5 items 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -349,7 +349,7 @@ exports[`ActionListCard should render 5 items 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -463,7 +463,7 @@ exports[`ActionListCard should render 5 items 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -577,7 +577,7 @@ exports[`ActionListCard should render 5 items 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -618,13 +618,13 @@ exports[`ActionListCard should render a loading state 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -649,7 +649,7 @@ exports[`ActionListCard should render a loading state 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -731,7 +731,7 @@ exports[`ActionListCard should render a loading state 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -840,7 +840,7 @@ exports[`ActionListCard should render a loading state 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -949,7 +949,7 @@ exports[`ActionListCard should render a loading state 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1058,7 +1058,7 @@ exports[`ActionListCard should render a loading state 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1167,7 +1167,7 @@ exports[`ActionListCard should render a loading state 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1228,13 +1228,13 @@ exports[`ActionListCard should render with a header 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1274,7 +1274,7 @@ exports[`ActionListCard should render with a header 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -1356,7 +1356,7 @@ exports[`ActionListCard should render with a header 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1470,7 +1470,7 @@ exports[`ActionListCard should render with a header 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1584,7 +1584,7 @@ exports[`ActionListCard should render with a header 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1698,7 +1698,7 @@ exports[`ActionListCard should render with a header 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1812,7 +1812,7 @@ exports[`ActionListCard should render with a header 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -1852,13 +1852,13 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1883,7 +1883,7 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
         Object {
           "backgroundColor": "#FFFFFF",
           "borderBottomWidth": 0,
-          "borderColor": "rgba(165, 165, 165, 0.6)",
+          "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderLeftWidth": 0,
           "borderRightWidth": 0,
           "borderTopWidth": 0,
@@ -1965,7 +1965,7 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2079,7 +2079,7 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2193,7 +2193,7 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2307,7 +2307,7 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",
@@ -2421,7 +2421,7 @@ exports[`ActionListCard should render with onPressActionListButton 1`] = `
             style={
               Object {
                 "borderBottomWidth": 0.5,
-                "borderColor": "rgba(165, 165, 165, 0.6)",
+                "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "flex": 1,
                 "height": 68,
                 "justifyContent": "center",

--- a/packages/apollos-ui-kit/src/Avatar/__snapshots__/Avatar.tests.js.snap
+++ b/packages/apollos-ui-kit/src/Avatar/__snapshots__/Avatar.tests.js.snap
@@ -94,13 +94,13 @@ exports[`The Avatar component should render icon button 1`] = `
           Object {
             "backgroundColor": "#FFFFFF",
             "padding": 3.2,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >

--- a/packages/apollos-ui-kit/src/CampusCard/__snapshots__/CampusCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/CampusCard/__snapshots__/CampusCard.tests.js.snap
@@ -10,6 +10,7 @@ exports[`CampusCard should render 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -159,6 +160,7 @@ exports[`CampusCard should render a loading 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -306,6 +308,7 @@ exports[`CampusCard should render with a title and description 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -395,6 +398,7 @@ exports[`CampusCard should render with a title and distance 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -495,6 +499,7 @@ exports[`CampusCard should render with a title and image 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -608,6 +613,7 @@ exports[`CampusCard should render with just a title 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -686,6 +692,7 @@ exports[`CampusCard should render without a description 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -823,6 +830,7 @@ exports[`CampusCard should render without a distance 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -949,6 +957,7 @@ exports[`CampusCard should render without an image 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,

--- a/packages/apollos-ui-kit/src/CampusCard/__snapshots__/CampusCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/CampusCard/__snapshots__/CampusCard.tests.js.snap
@@ -10,13 +10,13 @@ exports[`CampusCard should render 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -159,13 +159,13 @@ exports[`CampusCard should render a loading 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -306,13 +306,13 @@ exports[`CampusCard should render with a title and description 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -395,13 +395,13 @@ exports[`CampusCard should render with a title and distance 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -495,13 +495,13 @@ exports[`CampusCard should render with a title and image 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -608,13 +608,13 @@ exports[`CampusCard should render with just a title 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -686,13 +686,13 @@ exports[`CampusCard should render without a description 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -823,13 +823,13 @@ exports[`CampusCard should render without a distance 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -949,13 +949,13 @@ exports[`CampusCard should render without an image 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/Card/CardWrapper/__snapshots__/CardWrapper.tests.js.snap
+++ b/packages/apollos-ui-kit/src/Card/CardWrapper/__snapshots__/CardWrapper.tests.js.snap
@@ -9,13 +9,13 @@ exports[`the CardWrapper component should accept a backgroundColor 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -43,13 +43,13 @@ exports[`the CardWrapper component should accept additional props 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -73,13 +73,13 @@ exports[`the CardWrapper component should accept and render passed in styles 1`]
       "height": 400,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": "92%",
     }
   }
@@ -103,13 +103,13 @@ exports[`the CardWrapper component should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -132,13 +132,13 @@ exports[`the CardWrapper component should render children 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/Card/CardWrapper/index.js
+++ b/packages/apollos-ui-kit/src/Card/CardWrapper/index.js
@@ -16,6 +16,7 @@ const StyledCard = compose(
       ? {
           // provides spacing between cards also fixes android shadow needing "space" to render into
           margin: theme.sizing.baseUnit / 2,
+          marginBottom: theme.sizing.baseUnit * 0.75,
         }
       : {
           marginHorizontal: theme.sizing.baseUnit,

--- a/packages/apollos-ui-kit/src/Card/ErrorCard/__snapshots__/ErrorCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/Card/ErrorCard/__snapshots__/ErrorCard.tests.js.snap
@@ -8,13 +8,13 @@ exports[`the Card component should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -220,13 +220,13 @@ exports[`the Card component should render and not show the error message 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -432,13 +432,13 @@ exports[`the Card component should render with a custom message 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -644,13 +644,13 @@ exports[`the Card component should render with an error inside an object 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -858,13 +858,13 @@ exports[`the Card component should render with an error message inside an object
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/Card/__snapshots__/Card.tests.js.snap
+++ b/packages/apollos-ui-kit/src/Card/__snapshots__/Card.tests.js.snap
@@ -9,13 +9,13 @@ exports[`the Card component it should render a placeholder 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -150,13 +150,13 @@ exports[`the Card component should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/ContentCard/__snapshots__/ContentCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ContentCard/__snapshots__/ContentCard.tests.js.snap
@@ -8,13 +8,13 @@ exports[`ContentCard renders Basic card, with Image 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -312,13 +312,13 @@ exports[`ContentCard renders a Default Placeholder 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -500,13 +500,13 @@ exports[`ContentCard renders as Tile/Image only 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 495,
     }
   }
@@ -807,13 +807,13 @@ exports[`ContentCard renders as Tile/No image 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 495,
     }
   }
@@ -1082,13 +1082,13 @@ exports[`ContentCard renders basic tile card, with Image 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 495,
     }
   }
@@ -1393,13 +1393,13 @@ exports[`ContentCard renders with Default Placeholder 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 495,
     }
   }
@@ -1584,13 +1584,13 @@ exports[`ContentCard renders with No image 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1853,13 +1853,13 @@ exports[`ContentCard renders with an Image only 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/DefaultCard/__snapshots__/DefaultCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/DefaultCard/__snapshots__/DefaultCard.tests.js.snap
@@ -9,13 +9,13 @@ exports[`DefaultCard should render a loading state with isLoading 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -180,13 +180,13 @@ exports[`DefaultCard should render at the images natural aspect ratio (between m
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -316,13 +316,13 @@ exports[`DefaultCard should render at the maxAspectRatio bound (wider than tall)
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -452,13 +452,13 @@ exports[`DefaultCard should render at the minAspectRatio bound (tall-ish) 1`] = 
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -588,13 +588,13 @@ exports[`DefaultCard should render with a summary 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -740,13 +740,13 @@ exports[`DefaultCard should render with custom LabelComponent 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -922,13 +922,13 @@ exports[`DefaultCard should render with custom labelText 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1104,13 +1104,13 @@ exports[`DefaultCard should should render a like icon 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1366,13 +1366,13 @@ exports[`DefaultCard should should render as isLiked 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/FeaturedCard/__snapshots__/FeaturedCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/FeaturedCard/__snapshots__/FeaturedCard.tests.js.snap
@@ -9,13 +9,13 @@ exports[`FeaturedCard should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -168,13 +168,13 @@ exports[`FeaturedCard should render a loading state with isLoading 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -362,13 +362,13 @@ exports[`FeaturedCard should render with a custom actionIcon 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -635,13 +635,13 @@ exports[`FeaturedCard should render with a custom theme 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -793,13 +793,13 @@ exports[`FeaturedCard should render with a summary 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -966,13 +966,13 @@ exports[`FeaturedCard should render with custom LabelComponent 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1177,13 +1177,13 @@ exports[`FeaturedCard should render with custom labelText 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1388,13 +1388,13 @@ exports[`FeaturedCard should should render a like icon 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1673,13 +1673,13 @@ exports[`FeaturedCard should should render as isLiked 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1958,13 +1958,13 @@ exports[`FeaturedCard should should render as isLive 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -2272,13 +2272,13 @@ exports[`FeaturedCard should should render with an action "button" 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/FeedView/__snapshots__/FeedView.tests.js.snap
+++ b/packages/apollos-ui-kit/src/FeedView/__snapshots__/FeedView.tests.js.snap
@@ -70,13 +70,13 @@ exports[`The FeedView component handles a renderItem prop 1`] = `
             "borderRadius": 16,
             "marginHorizontal": 16,
             "marginVertical": 12,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >
@@ -336,13 +336,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -555,13 +555,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -774,13 +774,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -993,13 +993,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -1212,13 +1212,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -1431,13 +1431,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -1650,13 +1650,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -1869,13 +1869,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -2088,13 +2088,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -2307,13 +2307,13 @@ exports[`The FeedView component passes an onPressItem prop 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -2605,13 +2605,13 @@ exports[`The FeedView component renders correctly 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -2698,13 +2698,13 @@ exports[`The FeedView component renders correctly 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -2929,13 +2929,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -3148,13 +3148,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -3367,13 +3367,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -3586,13 +3586,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -3805,13 +3805,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -4024,13 +4024,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -4243,13 +4243,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -4462,13 +4462,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -4681,13 +4681,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >
@@ -4900,13 +4900,13 @@ exports[`The FeedView component renders empty state 1`] = `
               "borderRadius": 16,
               "marginHorizontal": 16,
               "marginVertical": 12,
-              "shadowColor": "rgba(165, 165, 165, 0.6)",
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 2,
                 "width": 0,
               },
               "shadowOpacity": 1,
-              "shadowRadius": 6,
+              "shadowRadius": 8,
             }
           }
         >

--- a/packages/apollos-ui-kit/src/HighlightCard/__snapshots__/HighlightCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/HighlightCard/__snapshots__/HighlightCard.tests.js.snap
@@ -10,13 +10,13 @@ exports[`HighlightCard should render a loading state with isLoading 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -192,13 +192,13 @@ exports[`HighlightCard should render in a "tall" aspect ratio (maxAspectRatio) 1
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -352,13 +352,13 @@ exports[`HighlightCard should render in a "wide" aspect ratio 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -512,13 +512,13 @@ exports[`HighlightCard should render with a custom actionIcon 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -787,13 +787,13 @@ exports[`HighlightCard should render with a custom theme 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -954,13 +954,13 @@ exports[`HighlightCard should render with a summary 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1129,13 +1129,13 @@ exports[`HighlightCard should render with custom LabelComponent 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1342,13 +1342,13 @@ exports[`HighlightCard should render with custom labelText 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1555,13 +1555,13 @@ exports[`HighlightCard should should render a like icon 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -1842,13 +1842,13 @@ exports[`HighlightCard should should render as isLiked 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -2129,13 +2129,13 @@ exports[`HighlightCard should should render as isLive 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -2289,13 +2289,13 @@ exports[`HighlightCard should should render with an action "button" 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/HorizontalDefaultCard/HorizontalDefaultCard.stories.js
+++ b/packages/apollos-ui-kit/src/HorizontalDefaultCard/HorizontalDefaultCard.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@apollosproject/ui-storybook';
-import { View, Dimensions } from 'react-native';
+import { View } from 'react-native';
 
 import BackgroundView from '../BackgroundView';
 import CenteredView from '../CenteredView';
@@ -85,7 +85,6 @@ storiesOf('ui-kit/HorizontalDefaultCard', module)
           content={HorizontalHighlightCardData}
           renderItem={renderHorizontalHighlightCard}
           loadingStateObject={loadingStateObject}
-          style={{ height: Dimensions.get('window').width * 0.66 + 32 }} // kind of a random math to just make this story work
         />
       </View>
     );

--- a/packages/apollos-ui-kit/src/HorizontalDefaultCard/__snapshots__/HorizontalDefaultCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/HorizontalDefaultCard/__snapshots__/HorizontalDefaultCard.tests.js.snap
@@ -9,13 +9,14 @@ exports[`HorizontalDefaultCard should render 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "marginBottom": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -136,13 +137,14 @@ exports[`HorizontalDefaultCard should render a loading state with isLoading 1`] 
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "marginBottom": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -289,13 +291,14 @@ exports[`HorizontalDefaultCard should render with a summary 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "marginBottom": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -447,13 +450,14 @@ exports[`HorizontalDefaultCard should render with a title 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "marginBottom": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -587,13 +591,14 @@ exports[`HorizontalDefaultCard should should render a like icon 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "marginBottom": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -853,13 +858,14 @@ exports[`HorizontalDefaultCard should should render as isLiked 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "marginBottom": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }

--- a/packages/apollos-ui-kit/src/HorizontalHighlightCard/__snapshots__/HorizontalHighlightCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/HorizontalHighlightCard/__snapshots__/HorizontalHighlightCard.tests.js.snap
@@ -9,13 +9,13 @@ exports[`HorizontalHighlightCard should render 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -170,13 +170,13 @@ exports[`HorizontalHighlightCard should render a loading state with isLoading 1`
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -356,13 +356,13 @@ exports[`HorizontalHighlightCard should render with a custom actionIcon 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -633,13 +633,13 @@ exports[`HorizontalHighlightCard should render with a custom theme 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -800,13 +800,13 @@ exports[`HorizontalHighlightCard should render with an action "button" 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -1123,13 +1123,13 @@ exports[`HorizontalHighlightCard should render with custom LabelComponent 1`] = 
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -1336,13 +1336,13 @@ exports[`HorizontalHighlightCard should render with custom labelText 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -1549,13 +1549,13 @@ exports[`HorizontalHighlightCard should should render as a like icon 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -1836,13 +1836,13 @@ exports[`HorizontalHighlightCard should should render as disabled 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 0,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }
@@ -1997,13 +1997,13 @@ exports[`HorizontalHighlightCard should should render as isLiked 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
-      "shadowColor": "transparent",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
       "width": 240,
     }
   }

--- a/packages/apollos-ui-kit/src/HorizontalHighlightCard/__snapshots__/HorizontalHighlightCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/HorizontalHighlightCard/__snapshots__/HorizontalHighlightCard.tests.js.snap
@@ -9,6 +9,7 @@ exports[`HorizontalHighlightCard should render 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -170,6 +171,7 @@ exports[`HorizontalHighlightCard should render a loading state with isLoading 1`
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -356,6 +358,7 @@ exports[`HorizontalHighlightCard should render with a custom actionIcon 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -633,6 +636,7 @@ exports[`HorizontalHighlightCard should render with a custom theme 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -800,6 +804,7 @@ exports[`HorizontalHighlightCard should render with an action "button" 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -1123,6 +1128,7 @@ exports[`HorizontalHighlightCard should render with custom LabelComponent 1`] = 
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -1336,6 +1342,7 @@ exports[`HorizontalHighlightCard should render with custom labelText 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -1549,6 +1556,7 @@ exports[`HorizontalHighlightCard should should render as a like icon 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -1836,6 +1844,7 @@ exports[`HorizontalHighlightCard should should render as disabled 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -1997,6 +2006,7 @@ exports[`HorizontalHighlightCard should should render as isLiked 1`] = `
       "borderRadius": 16,
       "height": 240,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,

--- a/packages/apollos-ui-kit/src/MediaThumbnail/__snapshots__/MediaThumbnail.tests.js.snap
+++ b/packages/apollos-ui-kit/src/MediaThumbnail/__snapshots__/MediaThumbnail.tests.js.snap
@@ -11,13 +11,13 @@ exports[`the MediaThumbnail component should render 1`] = `
       "height": 80,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/TableView/__snapshots__/TableView.tests.js.snap
+++ b/packages/apollos-ui-kit/src/TableView/__snapshots__/TableView.tests.js.snap
@@ -13,7 +13,7 @@ exports[`the TableView Component should render 1`] = `
       Object {
         "backgroundColor": "#FFFFFF",
         "borderBottomWidth": 0.5,
-        "borderColor": "rgba(165, 165, 165, 0.6)",
+        "borderColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "borderLeftWidth": 0,
         "borderRightWidth": 0,
         "borderTopWidth": 0.5,
@@ -173,7 +173,7 @@ exports[`the TableView Component should render 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "rgba(165, 165, 165, 0.6)",
+          "backgroundColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "height": 0.5,
           "marginLeft": 10.666666666666666,
           "width": "100%",
@@ -436,7 +436,7 @@ exports[`the TableView Component should render 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "rgba(165, 165, 165, 0.6)",
+          "backgroundColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "height": 0.5,
           "marginLeft": 10.666666666666666,
           "width": "100%",
@@ -478,7 +478,7 @@ exports[`the TableView Component should render 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "rgba(165, 165, 165, 0.6)",
+          "backgroundColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "height": 0.5,
           "marginLeft": 10.666666666666666,
           "width": "100%",

--- a/packages/apollos-ui-kit/src/ThumbnailCard/__snapshots__/ThumbnailCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ThumbnailCard/__snapshots__/ThumbnailCard.tests.js.snap
@@ -17,13 +17,13 @@ exports[`the ThumbnailCard component should render 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -91,13 +91,13 @@ exports[`the ThumbnailCard component should render a loading state 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -257,13 +257,13 @@ exports[`the ThumbnailCard component should render with a category 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -362,13 +362,13 @@ exports[`the ThumbnailCard component should render with a category and images 1`
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -528,13 +528,13 @@ exports[`the ThumbnailCard component should render with a description 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -623,13 +623,13 @@ exports[`the ThumbnailCard component should render with an images 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >

--- a/packages/apollos-ui-kit/src/ThumbnailCard/__snapshots__/ThumbnailCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ThumbnailCard/__snapshots__/ThumbnailCard.tests.js.snap
@@ -17,6 +17,7 @@ exports[`the ThumbnailCard component should render 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -91,6 +92,7 @@ exports[`the ThumbnailCard component should render a loading state 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -257,6 +259,7 @@ exports[`the ThumbnailCard component should render with a category 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -362,6 +365,7 @@ exports[`the ThumbnailCard component should render with a category and images 1`
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -528,6 +532,7 @@ exports[`the ThumbnailCard component should render with a description 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,
@@ -623,6 +628,7 @@ exports[`the ThumbnailCard component should render with an images 1`] = `
       "backgroundColor": "#FFFFFF",
       "borderRadius": 16,
       "margin": 8,
+      "marginBottom": 12,
       "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
         "height": 2,

--- a/packages/apollos-ui-kit/src/inputs/Picker/__snapshots__/Picker.tests.js.snap
+++ b/packages/apollos-ui-kit/src/inputs/Picker/__snapshots__/Picker.tests.js.snap
@@ -214,7 +214,7 @@ exports[`The Picker Input component focuses and blurs 1`] = `
       style={
         Object {
           "backgroundColor": "#FFFFFF",
-          "borderTopColor": "rgba(165, 165, 165, 0.6)",
+          "borderTopColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderTopWidth": 0.5,
           "bottom": 0,
           "left": 0,
@@ -567,7 +567,7 @@ exports[`The Picker Input component focuses and blurs 2`] = `
       style={
         Object {
           "backgroundColor": "#FFFFFF",
-          "borderTopColor": "rgba(165, 165, 165, 0.6)",
+          "borderTopColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderTopWidth": 0.5,
           "bottom": 0,
           "left": 0,
@@ -920,7 +920,7 @@ exports[`The Picker Input component focuses and blurs 3`] = `
       style={
         Object {
           "backgroundColor": "#FFFFFF",
-          "borderTopColor": "rgba(165, 165, 165, 0.6)",
+          "borderTopColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderTopWidth": 0.5,
           "bottom": 0,
           "left": 0,
@@ -1264,7 +1264,7 @@ exports[`The Picker Input component should render correctly 1`] = `
       style={
         Object {
           "backgroundColor": "#FFFFFF",
-          "borderTopColor": "rgba(165, 165, 165, 0.6)",
+          "borderTopColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "borderTopWidth": 0.5,
           "bottom": 0,
           "left": 0,

--- a/packages/apollos-ui-kit/src/theme/__snapshots__/createTheme.tests.js.snap
+++ b/packages/apollos-ui-kit/src/theme/__snapshots__/createTheme.tests.js.snap
@@ -79,7 +79,7 @@ Object {
     "screen": "#F8F7F4",
     "secondary": "#17B582",
     "shadows": Object {
-      "default": "rgba(165, 165, 165, 0.6)",
+      "default": "rgba(0, 0, 0, 0.09999999999999998)",
     },
     "tertiary": "#6EC5B8",
     "text": Object {
@@ -117,13 +117,13 @@ Object {
         "elevation": 5,
       },
       "ios": Object {
-        "shadowColor": "rgba(165, 165, 165, 0.6)",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       },
     },
     "none": Object {
@@ -163,7 +163,7 @@ Object {
           "secondary": "rgba(165, 165, 165, 0.5)",
         },
         "shadows": Object {
-          "default": "transparent",
+          "default": "rgba(0, 0, 0, 0.09999999999999998)",
         },
         "text": Object {
           "link": "#17B582",
@@ -190,7 +190,7 @@ Object {
           "secondary": "#FFFFFF",
         },
         "shadows": Object {
-          "default": "rgba(165, 165, 165, 0.6)",
+          "default": "rgba(0, 0, 0, 0.09999999999999998)",
         },
         "text": Object {
           "link": "#17B582",
@@ -268,7 +268,7 @@ Object {
   "screen": "#F8F7F4",
   "secondary": "#17B582",
   "shadows": Object {
-    "default": "rgba(165, 165, 165, 0.6)",
+    "default": "rgba(0, 0, 0, 0.09999999999999998)",
   },
   "tertiary": "#6EC5B8",
   "text": Object {
@@ -401,7 +401,7 @@ Object {
     "screen": "#F8F7F4",
     "secondary": "#17B582",
     "shadows": Object {
-      "default": "transparent",
+      "default": "rgba(0, 0, 0, 0.09999999999999998)",
     },
     "tertiary": "#6EC5B8",
     "text": Object {
@@ -435,13 +435,13 @@ Object {
         "elevation": 5,
       },
       "ios": Object {
-        "shadowColor": "transparent",
+        "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 6,
+        "shadowRadius": 8,
       },
     },
     "none": Object {
@@ -481,7 +481,7 @@ Object {
           "secondary": "rgba(165, 165, 165, 0.5)",
         },
         "shadows": Object {
-          "default": "transparent",
+          "default": "rgba(0, 0, 0, 0.09999999999999998)",
         },
         "text": Object {
           "link": "#17B582",
@@ -508,7 +508,7 @@ Object {
           "secondary": "#FFFFFF",
         },
         "shadows": Object {
-          "default": "rgba(165, 165, 165, 0.6)",
+          "default": "rgba(0, 0, 0, 0.09999999999999998)",
         },
         "text": Object {
           "link": "#17B582",

--- a/packages/apollos-ui-kit/src/theme/defaultTheme.js
+++ b/packages/apollos-ui-kit/src/theme/defaultTheme.js
@@ -114,10 +114,10 @@ export const shadows = ({ colors: themeColors }) => ({
       shadowColor: themeColors.shadows.default,
       shadowOffset: {
         width: 0,
-        height: 1,
+        height: 2,
       },
       shadowOpacity: 1,
-      shadowRadius: 6,
+      shadowRadius: 8,
     },
     android: {
       elevation: 5,

--- a/packages/apollos-ui-kit/src/theme/types/dark.js
+++ b/packages/apollos-ui-kit/src/theme/types/dark.js
@@ -20,7 +20,9 @@ const dark = ({ colors, alpha }) => ({
       inactive: colors.darkTertiary,
     },
     shadows: {
-      default: colors.transparent,
+      default: Color(colors.black)
+        .fade(alpha.high)
+        .string(),
     },
     action: {
       default: colors.darkTertiary,

--- a/packages/apollos-ui-kit/src/theme/types/light.js
+++ b/packages/apollos-ui-kit/src/theme/types/light.js
@@ -18,8 +18,8 @@ const light = ({ barStyle, colors, alpha }) => ({
       inactive: colors.lightTertiary,
     },
     shadows: {
-      default: Color(colors.darkTertiary)
-        .fade(alpha.low)
+      default: Color(colors.black)
+        .fade(0.06)
         .string(),
     },
     action: {

--- a/packages/apollos-ui-kit/src/theme/types/light.js
+++ b/packages/apollos-ui-kit/src/theme/types/light.js
@@ -19,7 +19,7 @@ const light = ({ barStyle, colors, alpha }) => ({
     },
     shadows: {
       default: Color(colors.black)
-        .fade(0.06)
+        .fade(alpha.high)
         .string(),
     },
     action: {

--- a/packages/apollos-ui-mapview/src/MapView/__snapshots__/MapView.tests.js.snap
+++ b/packages/apollos-ui-mapview/src/MapView/__snapshots__/MapView.tests.js.snap
@@ -64,6 +64,7 @@ exports[`<MapView> should render 1`] = `
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
@@ -207,6 +208,7 @@ Richardson, TX 75080-5525
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
@@ -479,6 +481,7 @@ exports[`<MapView> should render with a custom buttonTitle 1`] = `
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
@@ -622,6 +625,7 @@ Richardson, TX 75080-5525
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {

--- a/packages/apollos-ui-mapview/src/MapView/__snapshots__/MapView.tests.js.snap
+++ b/packages/apollos-ui-mapview/src/MapView/__snapshots__/MapView.tests.js.snap
@@ -65,13 +65,13 @@ exports[`<MapView> should render 1`] = `
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }
@@ -208,13 +208,13 @@ Richardson, TX 75080-5525
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }
@@ -480,13 +480,13 @@ exports[`<MapView> should render with a custom buttonTitle 1`] = `
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }
@@ -623,13 +623,13 @@ Richardson, TX 75080-5525
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }

--- a/packages/apollos-ui-mapview/src/MapViewConnected/__snapshots__/MapViewConnected.tests.js.snap
+++ b/packages/apollos-ui-mapview/src/MapViewConnected/__snapshots__/MapViewConnected.tests.js.snap
@@ -66,13 +66,13 @@ exports[`The MapViewConnected component should render 1`] = `
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }
@@ -233,13 +233,13 @@ South Barrington, IL 60010-6143
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }
@@ -400,13 +400,13 @@ Anderson, SC 29621-3619
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }
@@ -567,13 +567,13 @@ Richardson, TX 75080-5525
                 "borderRadius": 16,
                 "margin": 8,
                 "marginHorizontal": 4,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
                 "width": 714,
               }
             }

--- a/packages/apollos-ui-mapview/src/MapViewConnected/__snapshots__/MapViewConnected.tests.js.snap
+++ b/packages/apollos-ui-mapview/src/MapViewConnected/__snapshots__/MapViewConnected.tests.js.snap
@@ -65,6 +65,7 @@ exports[`The MapViewConnected component should render 1`] = `
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
@@ -232,6 +233,7 @@ South Barrington, IL 60010-6143
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
@@ -399,6 +401,7 @@ Anderson, SC 29621-3619
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
@@ -566,6 +569,7 @@ Richardson, TX 75080-5525
                 "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
                 "margin": 8,
+                "marginBottom": 12,
                 "marginHorizontal": 4,
                 "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {

--- a/packages/apollos-ui-media-player/src/MediaPlayer/__snapshots__/FullscreenPlayer.tests.js.snap
+++ b/packages/apollos-ui-media-player/src/MediaPlayer/__snapshots__/FullscreenPlayer.tests.js.snap
@@ -1225,13 +1225,13 @@ exports[`the FullscreenPlayer component should hide disabled controls 1`] = `
         style={
           Object {
             "borderRadius": 8,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >
@@ -3265,13 +3265,13 @@ exports[`the FullscreenPlayer component should render a custom VideoWindow compo
         style={
           Object {
             "borderRadius": 8,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >
@@ -5305,13 +5305,13 @@ exports[`the FullscreenPlayer component should render fullscreen 1`] = `
         style={
           Object {
             "borderRadius": 8,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >
@@ -7345,13 +7345,13 @@ exports[`the FullscreenPlayer component should render miniplayer with audio 1`] 
         style={
           Object {
             "borderRadius": 8,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >
@@ -9385,13 +9385,13 @@ exports[`the FullscreenPlayer component should render miniplayer with video 1`] 
         style={
           Object {
             "borderRadius": 8,
-            "shadowColor": "rgba(165, 165, 165, 0.6)",
+            "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 2,
               "width": 0,
             },
             "shadowOpacity": 1,
-            "shadowRadius": 6,
+            "shadowRadius": 8,
           }
         }
       >

--- a/packages/apollos-ui-onboarding/src/slides/LocationFinder/__snapshots__/LocationFinder.tests.js.snap
+++ b/packages/apollos-ui-onboarding/src/slides/LocationFinder/__snapshots__/LocationFinder.tests.js.snap
@@ -888,13 +888,13 @@ Array [
                 "borderRadius": 16,
                 "margin": 8,
                 "marginBottom": 16,
-                "shadowColor": "rgba(165, 165, 165, 0.6)",
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
                 "shadowOffset": Object {
-                  "height": 1,
+                  "height": 2,
                   "width": 0,
                 },
                 "shadowOpacity": 1,
-                "shadowRadius": 6,
+                "shadowRadius": 8,
               }
             }
           >

--- a/packages/apollos-ui-passes/src/PassView/__tests__/__snapshots__/PassView.tests.js.snap
+++ b/packages/apollos-ui-passes/src/PassView/__tests__/__snapshots__/PassView.tests.js.snap
@@ -9,13 +9,13 @@ exports[`the PassView component should display loading placeholders 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >
@@ -160,13 +160,13 @@ exports[`the PassView component should render 1`] = `
       "borderRadius": 16,
       "marginHorizontal": 16,
       "marginVertical": 12,
-      "shadowColor": "rgba(165, 165, 165, 0.6)",
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 6,
+      "shadowRadius": 8,
     }
   }
 >


### PR DESCRIPTION
## DESCRIPTION
This PR updates the default shadow value for Core

### What does this PR do, or why is it needed?
The initial shadows were darker than intended because they were using `.fade(alpha.low)` which is effectively 40% opacity. This matches what is in Figma by using `colors.black` instead of `colors.darkTertiary` and having transparency be 6% instead of 40%.

### What design trade-offs/decisions were made?
The current opacity that is being faded is hard-coded instead of being tied to the theme. This is because our lightest alpha value is 40%.

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [x] Manual QA on iOS and ensure it looks/behaves as expected
- [x] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
