### PR TITLE
Add command to update stories on yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "scripts": {
-    "start": "lerna run build && yarn push-all && yarn build:api-watch",
+    "start": "lerna run generate-stories && lerna run build && yarn push-all && yarn build:api-watch",
     "build:api-watch": "node ./scripts/watch.js",
     "link-packages": "lerna exec -- yarn yalc publish",
     "unlink-packages": "lerna exec -- yarn yalc installations clean",
@@ -33,7 +33,8 @@
     "nuke:node": "rm -rdf ./node_modules packages/*/node_modules && yarn cache clean && yarn",
     "nuke:cache": "watchman watch-del-all",
     "postinstall": "lerna run build --parallel",
-    "generate-docs": "lerna run generate-docs"
+    "generate-docs": "lerna run generate-docs",
+    "generate-stories": "rnstl --searchDir ./src --pattern **/*.stories.js"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"


### PR DESCRIPTION
### What does this PR do, or why is it needed?
When working with storybook and switching between branches there is no easy way to update storybook to know that files might have been added or removed. This just "complies" the list of stories with `yarn start` like we use to do.

### What design trade-offs/decisions were made?
Might take a fraction of a sec longer to run `yarn start` now.
### How do I test this PR?
`yarn start` and see that stories were complied.

### What automated tests did you write?

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
