### PR TITLE
Fixes crash in search on android

### DIFF
--- a/packages/apollos-ui-kit/src/inputs/Search/__snapshots__/Search.tests.js.snap
+++ b/packages/apollos-ui-kit/src/inputs/Search/__snapshots__/Search.tests.js.snap
@@ -142,7 +142,6 @@ exports[`The Search Input component should render 1`] = `
     <TextInput
       allowFontScaling={true}
       cancelButtonOffset={1000}
-      color="#303030"
       editable={true}
       isFocused={false}
       onChangeText={[Function]}
@@ -154,6 +153,7 @@ exports[`The Search Input component should render 1`] = `
       selectionColor="#17B582"
       style={
         Object {
+          "color": "#303030",
           "flexGrow": 1,
           "fontFamily": "System",
           "fontSize": 14,
@@ -515,7 +515,6 @@ exports[`The Search Input component should render as disabled 1`] = `
     <TextInput
       allowFontScaling={true}
       cancelButtonOffset={1000}
-      color="#303030"
       editable={false}
       isFocused={false}
       onChangeText={[Function]}
@@ -527,6 +526,7 @@ exports[`The Search Input component should render as disabled 1`] = `
       selectionColor="#17B582"
       style={
         Object {
+          "color": "#303030",
           "flexGrow": 1,
           "fontFamily": "System",
           "fontSize": 14,
@@ -887,7 +887,6 @@ exports[`The Search Input component should render with a custom cancelButtonText
     <TextInput
       allowFontScaling={true}
       cancelButtonOffset={1000}
-      color="#303030"
       editable={true}
       isFocused={false}
       onChangeText={[Function]}
@@ -899,6 +898,7 @@ exports[`The Search Input component should render with a custom cancelButtonText
       selectionColor="#17B582"
       style={
         Object {
+          "color": "#303030",
           "flexGrow": 1,
           "fontFamily": "System",
           "fontSize": 14,
@@ -1259,7 +1259,6 @@ exports[`The Search Input component should render with a custom placeholder 1`] 
     <TextInput
       allowFontScaling={true}
       cancelButtonOffset={1000}
-      color="#303030"
       editable={true}
       isFocused={false}
       onChangeText={[Function]}
@@ -1271,6 +1270,7 @@ exports[`The Search Input component should render with a custom placeholder 1`] 
       selectionColor="#17B582"
       style={
         Object {
+          "color": "#303030",
           "flexGrow": 1,
           "fontFamily": "System",
           "fontSize": 14,
@@ -1631,7 +1631,6 @@ exports[`The Search Input component should render with a custom screenBackground
     <TextInput
       allowFontScaling={true}
       cancelButtonOffset={1000}
-      color="#303030"
       editable={true}
       isFocused={false}
       onChangeText={[Function]}
@@ -1643,6 +1642,7 @@ exports[`The Search Input component should render with a custom screenBackground
       selectionColor="#17B582"
       style={
         Object {
+          "color": "#303030",
           "flexGrow": 1,
           "fontFamily": "System",
           "fontSize": 14,

--- a/packages/apollos-ui-kit/src/inputs/Search/styles.js
+++ b/packages/apollos-ui-kit/src/inputs/Search/styles.js
@@ -39,8 +39,8 @@ const LoopIcon = withTheme(({ theme, isFocused }) => ({
 const Input = withTheme(({ theme, isFocused, cancelButtonOffset }) => ({
   placeholderTextColor: theme.colors.text.tertiary,
   selectionColor: theme.colors.action.secondary,
-  color: theme.colors.text.primary,
   style: {
+    color: theme.colors.text.primary, // fixes android text color when switching theme types
     flexGrow: 1, // fixes weird text behind icon (ios) and placeholder clipping (android) bugs
     height: theme.helpers.rem(2.5), // we have to have a height to make this display correctly. using typographic unit to scale with text size.
     paddingVertical: 0, // removes weird "default" padding


### PR DESCRIPTION
## DESCRIPTION
This bug was introduced to support "dark mode" as a result I tested this in both dark and light theme types.

<img src="https://user-images.githubusercontent.com/2053547/80495055-693b7e00-8935-11ea-8493-c24b2d260ab4.gif" width="30%" /><img src="https://user-images.githubusercontent.com/2053547/80495085-73f61300-8935-11ea-9a0f-12491133113f.gif" width="30%" />

### What does this PR do, or why is it needed?
All this does is move the `color` style definition into the `style` object one line below it 💥
### What design trade-offs/decisions were made?
N/A
### How do I test this PR?
1. Open the app on android.
2. Tap on discover.
3. No crash? 🙌 

You're welcome to switch theme types to see how the text colors render if you want too.
### What automated tests did you write?
None. This fix only concerns android and jest doesn't cover android 😢 

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
