### PR TITLE
Fix auth logout errors

### DIFF
--- a/packages/apollos-ui-auth/src/Provider.js
+++ b/packages/apollos-ui-auth/src/Provider.js
@@ -24,11 +24,11 @@ export const GET_AUTH_TOKEN = gql`
 export const resolvers = {
   Query: {
     authToken: () => AsyncStorage.getItem('authToken'),
-    isLoggedIn: (_root, _args, { cache }) => {
+    isLoggedIn: async (_root, _args, { cache }) => {
       // When logging out, this query returns an error.
       // Rescue the error, and return false.
       try {
-        const { authToken } = cache.readQuery({ query: GET_AUTH_TOKEN });
+        const authToken = await AsyncStorage.getItem('authToken');
         return !!authToken;
       } catch (e) {
         return false;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

**Here's my theory on what's happening:**

- We currently do not delay rendering the app before the app cache is loaded, so the app mounts right away
- On initial mount, we render a [`ProtectedRoute`](https://github.com/ApollosProject/apollos-templates/blob/d79e5794477f89d19168ba47038ebba0693e041c/apolloschurchapp/src/index.js#L56)
- This `ProtectedMount` queries for [ both `cacheLoaded` as well as `isLoggedIn` ](https://github.com/ApollosProject/apollos-apps/blob/master/packages/apollos-ui-auth/src/getLoginStateWithCacheLoaded.js#L10-L11)
-. I believe this could cause an unintended consequence when the following happens in order:

1. the app mounts with no cache
2. the `ProtectedRoute` queries fires a query for both `cacheLoaded` and `isLoggedIn`
3. `isLoggedIn` tries to read from cache for `authToken`. The cache is empty, so `null` (or `undefined`) is returned. `cacheLoaded` is also returned as false, so the component displays a loading state
4. The cache finally persists, and the query gets updated.
5. However, for some reason `authToken` is not a part of the cache that gets persisted. 

---

After doing another read through our code this morning, I came up with these thoughts:

Regarding the logout bug, it seems like we know it happens on app launch

a couple things happen on app launch, like restoring cache

i tried to look and see how persistance on `AsyncStorage works` to see if that could ever be tampered....like if the user was low on disk space
but I didn't find anything

However, it doesn't look like we delay rendering until the cahce is loaded - https://github.com/ApollosProject/apollos-templates/blob/4e6869d287e9793eedb92b9f3f578aca54429031/apolloschurchapp/src/client/index.js#L76

So, essentially the app can fully render before the cache has been restored

This auth package looks at both cache and `AsyncStorage` for determining login state. Some of the auth state is in cache, like `isLoggedIn`

Of which, the query for isLoggedIn reads the authToken from cache instead of from AsyncStorage - https://github.com/ApollosProject/apollos-apps/blob/master/packages/apollos-ui-auth/src/Provider.js#L31 

But, this query doesn't check for cacheMarkLoaded
So, i wonder if we should just look for the `authToken` from `AsyncStorage` here instead,  which is what this PR does.

**I have not tested this yet**


### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
