### PR TITLE
Default link text color to secondary on Webview feature

### DIFF
--- a/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/WebviewFeature.js
+++ b/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/WebviewFeature.js
@@ -35,7 +35,7 @@ const StyledH3 = styled(
 
 const StyledText = styled(
   ({ theme }) => ({
-    color: theme.colors.screen,
+    color: theme.colors.secondary,
     paddingHorizontal: theme.sizing.baseUnit,
   }),
   'ui-connected.WebviewFeature.StyledText'

--- a/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/__snapshots__/ContentSingleFeaturesConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/__snapshots__/ContentSingleFeaturesConnected.tests.js.snap
@@ -100,7 +100,7 @@ exports[`ContentSingleFeaturesConnected should render 1`] = `
         <Text
           style={
             Object {
-              "color": "#F8F7F4",
+              "color": "#17B582",
               "fontFamily": "System",
               "fontSize": 14,
               "fontStyle": null,


### PR DESCRIPTION
## DESCRIPTION
Simply just changed the default color variable to `secondary` for the link in the Webview Feature header (Open in Spotify).
![image](https://user-images.githubusercontent.com/2528817/81440079-1338b880-9135-11ea-92ff-624253f46d44.png)

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
