### PR TITLE
Ensure SearchCards without images still render

### DIFF
--- a/packages/apollos-ui-connected/src/SearchCardConnected/SearchCardConnected.tests.js
+++ b/packages/apollos-ui-connected/src/SearchCardConnected/SearchCardConnected.tests.js
@@ -66,5 +66,5 @@ describe('The SearchCardConnected component', () => {
       </Providers>
     );
     expect(tree).toMatchSnapshot();
-  });  
+  });
 });

--- a/packages/apollos-ui-connected/src/SearchCardConnected/SearchCardConnected.tests.js
+++ b/packages/apollos-ui-connected/src/SearchCardConnected/SearchCardConnected.tests.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 
-import { Providers } from '../utils/testUtils';
+import { Providers, renderWithApolloData } from '../utils/testUtils';
 
 import SearchCardConnected from '.';
 
 describe('The SearchCardConnected component', () => {
-  it('should render', () => {
+  it('should render', async () => {
     const data = {
       title: 'How to lead people to Jesus',
       summary:
@@ -25,37 +24,12 @@ describe('The SearchCardConnected component', () => {
       cursor: 'b487224762b030f470967f45d7205823',
       node: {
         id: 'DevotionalContentItem:561dfb7dbd8a5c093fd8385c7edaadbc',
-        title: 'How to lead people to Jesus',
-        hyphenatedTitle: '-',
-        isLiked: false,
-        likedCount: 0,
-        summary:
-          'Love compels a mother to lose all dignity in public as she screams the name of her lost child.',
-        coverImage: {
-          name: 'Square Image',
-          sources: [
-            {
-              uri:
-                'https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dd3a96243-2558-4c04-bf41-3aadcf41771f',
-              __typename: 'ImageMediaSource',
-            },
-          ],
-          __typename: 'ImageMedia',
-        },
-        theme: null,
-        parentChannel: {
-          id: 'ContentChannel:559b23fd0aa90e81b1c023e72e230fa1',
-          name: 'Devotional',
-          __typename: 'ContentChannel',
-        },
-        videos: [{ sources: [], __typename: 'VideoMedia' }],
-        audios: [],
         __typename: 'DevotionalContentItem',
       },
       __typename: 'SearchResult',
     };
 
-    const tree = renderer.create(
+    const tree = await renderWithApolloData(
       <Providers>
         <SearchCardConnected
           coverImage={data.coverImage}
@@ -67,4 +41,30 @@ describe('The SearchCardConnected component', () => {
     );
     expect(tree).toMatchSnapshot();
   });
+  it('should render without image', async () => {
+    const data = {
+      title: 'How to lead people to Jesus',
+      summary:
+        'Love compels a mother to lose all dignity in public as she screams the name of her lost child.',
+      coverImage: null,
+      cursor: 'b487224762b030f470967f45d7205823',
+      node: {
+        id: 'DevotionalContentItem:561dfb7dbd8a5c093fd8385c7edaadbc',
+        __typename: 'DevotionalContentItem',
+      },
+      __typename: 'SearchResult',
+    };
+
+    const tree = await renderWithApolloData(
+      <Providers>
+        <SearchCardConnected
+          coverImage={data.coverImage}
+          summary={data.summary}
+          title={data.title}
+          node={data.node}
+        />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });  
 });

--- a/packages/apollos-ui-connected/src/SearchCardConnected/__snapshots__/SearchCardConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/SearchCardConnected/__snapshots__/SearchCardConnected.tests.js.snap
@@ -36,51 +36,33 @@ exports[`The SearchCardConnected component should render 1`] = `
         }
       }
     >
-      <View
-        animate={null}
-        customAnimate={null}
-        onReady={false}
+      <RCTImageView
+        maxAspectRatio={1.2}
+        minAspectRatio={0.75}
+        onLoad={[Function]}
+        resizeMode="cover"
+        source={
+          Array [
+            Object {
+              "__typename": "ImageMediaSource",
+              "cache": "force-cache",
+              "height": 600,
+              "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dd3a96243-2558-4c04-bf41-3aadcf41771f",
+              "width": 500,
+            },
+          ]
+        }
         style={
           Object {
-            "aspectRatio": 1,
+            "aspectRatio": 0.8333333333333334,
             "backgroundColor": "#A5A5A5",
+            "opacity": 0,
+            "overflow": "hidden",
             "resizeMode": "cover",
             "width": "100%",
           }
         }
-      >
-        <RCTImageView
-          maxAspectRatio={1.2}
-          minAspectRatio={0.75}
-          onLoad={[Function]}
-          resizeMode="cover"
-          source={
-            Array [
-              Object {
-                "__typename": "ImageMedia",
-                "cache": "force-cache",
-                "name": "Square Image",
-                "sources": Array [
-                  Object {
-                    "__typename": "ImageMediaSource",
-                    "uri": "https://res.cloudinary.com/apollos/image/fetch/c_limit,f_auto,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Dd3a96243-2558-4c04-bf41-3aadcf41771f",
-                  },
-                ],
-                "uri": "",
-              },
-            ]
-          }
-          style={
-            Object {
-              "backgroundColor": "#A5A5A5",
-              "opacity": 0,
-              "overflow": "hidden",
-              "resizeMode": "cover",
-              "width": "100%",
-            }
-          }
-        />
-      </View>
+      />
       <BVLinearGradient
         colors={
           Array [
@@ -181,132 +163,154 @@ exports[`The SearchCardConnected component should render 1`] = `
         </View>
       </View>
     </View>
+  </View>
+</View>
+`;
+
+exports[`The SearchCardConnected component should render without image 1`] = `
+<View
+  cardColor="#00676D"
+  style={
+    Object {
+      "backgroundColor": "#00676D",
+      "borderRadius": 16,
+      "marginHorizontal": 16,
+      "marginVertical": 12,
+      "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+      "shadowOffset": Object {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 8,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderRadius": 16,
+        "overflow": "hidden",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "position": "absolute",
-          "right": 24,
-          "top": 24,
+          "backgroundColor": "#A5A5A5",
+          "overflow": "hidden",
+          "width": "100%",
         }
       }
     >
-      <RNSVGSvgView
-        align="xMidYMid"
-        bbHeight={24}
-        bbWidth={24}
-        height={24}
-        iconPadding={24}
-        isLiked={false}
-        meetOrSlice={0}
-        minX={0}
-        minY={0}
+      <View
         style={
+          Object {
+            "aspectRatio": 1,
+            "backgroundColor": "#A5A5A5",
+            "width": "100%",
+          }
+        }
+      />
+      <BVLinearGradient
+        colors={
           Array [
-            Object {
-              "backgroundColor": "transparent",
-              "borderWidth": 0,
-            },
-            undefined,
-            null,
-            Object {
-              "flex": 0,
-              "height": 24,
-              "width": 24,
-            },
+            1711276032,
+            2147483648,
           ]
         }
-        vbHeight={24}
-        vbWidth={24}
-        width={24}
+        endPoint={
+          Object {
+            "x": 0,
+            "y": 1,
+          }
+        }
+        locations={
+          Array [
+            0,
+            1,
+          ]
+        }
+        overlayColor="#000000"
+        overlayType="gradient-bottom"
+        startPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "flex-start",
+          "bottom": 0,
+          "paddingBottom": 32,
+          "paddingHorizontal": 24,
+          "paddingVertical": 16,
+          "position": "absolute",
+          "width": "100%",
+        }
+      }
+    >
+      <Text
+        numberOfLines={3}
+        style={
+          Object {
+            "color": "#F8F7F4",
+            "fontFamily": "InterUI-Black",
+            "fontSize": 24,
+            "lineHeight": 27.6,
+          }
+        }
       >
-        <RNSVGGroup
-          fill={
-            Array [
-              0,
-              4278190080,
-            ]
+        How to lead people to Jesus
+      </Text>
+      <View
+        hasSummary={true}
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingTop": 16,
           }
-          fillOpacity={1}
-          fillRule={1}
-          font={Object {}}
-          matrix={
-            Array [
-              1,
-              0,
-              0,
-              1,
-              0,
-              0,
-            ]
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "marginRight": 16,
+            }
           }
-          opacity={1}
-          originX={0}
-          originY={0}
-          propList={Array []}
-          rotation={0}
-          scaleX={1}
-          scaleY={1}
-          skewX={0}
-          skewY={0}
-          stroke={null}
-          strokeDasharray={null}
-          strokeDashoffset={null}
-          strokeLinecap={0}
-          strokeLinejoin={0}
-          strokeMiterlimit={4}
-          strokeOpacity={1}
-          strokeWidth={1}
-          vectorEffect={0}
-          x={0}
-          y={0}
         >
-          <RNSVGPath
-            d="M13.13 20.2h-2.26l1.4-1.4.03-.02.03-.03c6.37-5.6 8.06-7.67 8.06-10.27 0-2.2-1.7-3.9-3.9-3.9-1.23 0-2.48.6-3.28 1.54L12 7.57l-1.23-1.45C9.97 5.18 8.72 4.6 7.5 4.6c-2.2 0-3.9 1.67-3.9 3.88 0 2.6 1.7 4.66 8.07 10.27l.03.03.04.03 1.4 1.4zM10.8 4.03l-.03.03h.1c.4.3.8.64 1.13 1.03.33-.4.72-.75 1.14-1.05h.1c-.02 0-.03-.02-.04-.03.97-.66 2.13-1.03 3.3-1.03C19.6 3 22 5.4 22 8.47c0 3.8-3.4 6.88-8.6 11.46l-1.4 1.4-1.4-1.4C5.4 15.36 2 12.27 2 8.48 2 5.38 4.4 3 7.5 3c1.17 0 2.33.37 3.3 1.03z"
-            fill={
-              Array [
-                0,
-                4294506484,
-              ]
+          <Text
+            bold={false}
+            italic={false}
+            numberOfLines={2}
+            style={
+              Object {
+                "color": "#F8F7F4",
+                "fontFamily": "InterUI-Regular",
+                "fontSize": 16,
+                "lineHeight": 26,
+              }
             }
-            fillOpacity={1}
-            fillRule={1}
-            matrix={
-              Array [
-                1,
-                0,
-                0,
-                1,
-                0,
-                0,
-              ]
-            }
-            opacity={1}
-            originX={0}
-            originY={0}
-            propList={
-              Array [
-                "fill",
-              ]
-            }
-            rotation={0}
-            scaleX={1}
-            scaleY={1}
-            skewX={0}
-            skewY={0}
-            stroke={null}
-            strokeDasharray={null}
-            strokeDashoffset={null}
-            strokeLinecap={0}
-            strokeLinejoin={0}
-            strokeMiterlimit={4}
-            strokeOpacity={1}
-            strokeWidth={1}
-            vectorEffect={0}
-            x={0}
-            y={0}
-          />
-        </RNSVGGroup>
-      </RNSVGSvgView>
+          >
+            Love compels a mother to lose all dignity in public as she screams the name of her lost child.
+          </Text>
+        </View>
+      </View>
     </View>
   </View>
 </View>

--- a/packages/apollos-ui-connected/src/SearchCardConnected/index.js
+++ b/packages/apollos-ui-connected/src/SearchCardConnected/index.js
@@ -27,7 +27,7 @@ const SearchCardConnected = memo(
 
     return (
       <Component
-        coverImage={get(coverImage, 'sources', [])}
+        coverImage={get(coverImage, 'sources', undefined)}
         hasAction={hasAction}
         isLoading={isLoading}
         summary={summary}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

At present, items that don't have images don't show up, period, when they are a HighlightCard. I don't know the exact Root of this, I believe it's do to the logic with how the <Image> component is rendered. 

To fix, we need to do what the `ContentCardConnected` does and default a content item without an image to have a `coverImage` of `undefined`. 

This fix was successfully deployed on Grace.

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

Download Grace and search :)

### What automated tests did you write?

New tests over new image state.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
