### PR TITLE
Adds an `onPressBackground` prop to the `PrayerScreen` component

### DIFF
--- a/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.stories.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.stories.js
@@ -27,4 +27,6 @@ storiesOf('ui-prayer/PrayerScreen', module)
       <Text>Hello World</Text>
     </PrayerScreen>
   ))
-  .add('buttonText', () => <PrayerScreen buttonText={'Custom buttonText'} />);
+  .add('primaryActionText', () => (
+    <PrayerScreen primaryActionText={'Custom primaryActionText'} />
+  ));

--- a/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.tests.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.tests.js
@@ -27,10 +27,10 @@ describe('The PrayerScreen component', () => {
 
     expect(tree).toMatchSnapshot();
   });
-  it('should render with custom buttonText', () => {
+  it('should render with custom primaryActionText', () => {
     const tree = renderer.create(
       <Providers>
-        <PrayerScreen buttonText={'Custom buttonText'} />
+        <PrayerScreen primaryActionText={'Custom primaryActionText'} />
       </Providers>
     );
 

--- a/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.tests.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.tests.js
@@ -45,10 +45,10 @@ describe('The PrayerScreen component', () => {
 
     expect(tree).toMatchSnapshot();
   });
-  it('should accept an onPressButton function', () => {
+  it('should accept an onPressPrimary function', () => {
     const tree = renderer.create(
       <Providers>
-        <PrayerScreen onPressButton={jest.fn()} />
+        <PrayerScreen onPressPrimary={jest.fn()} />
       </Providers>
     );
 

--- a/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.tests.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/PrayerScreen.tests.js
@@ -36,7 +36,16 @@ describe('The PrayerScreen component', () => {
 
     expect(tree).toMatchSnapshot();
   });
-  it('should render accept an onPressButton function', () => {
+  it('should accept an onPressBackground function', () => {
+    const tree = renderer.create(
+      <Providers>
+        <PrayerScreen onPressBackground={jest.fn()} />
+      </Providers>
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+  it('should accept an onPressButton function', () => {
     const tree = renderer.create(
       <Providers>
         <PrayerScreen onPressButton={jest.fn()} />

--- a/packages/apollos-ui-prayer/src/PrayerScreen/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/index.js
@@ -11,16 +11,12 @@ import PropTypes from 'prop-types';
 
 import {
   Button,
+  ButtonText,
   PaddedView,
   styled,
   withIsLoading,
   withTheme,
 } from '@apollosproject/ui-kit';
-
-const ButtonWithProps = withTheme(
-  () => ({}),
-  'ui-prayer.PrayerScreen.ButtonWithProps'
-)(Button);
 
 const Content = styled(
   {
@@ -43,12 +39,36 @@ const FlexedScrollView = withTheme(
   'ui-prayer.PrayerScreen.FlexedScrollView'
 )(ScrollView);
 
+const PrimaryButton = withTheme(
+  () => ({}),
+  'ui-prayer.PrayerScreen.PrimaryButton'
+)(Button);
+
+const SecondaryAction = styled({})(ButtonText);
+
+const SecondaryActionWrapper = styled(
+  {
+    flexDirection: 'row',
+  },
+  'ui-prayer.PrayerScreen.SecondaryActionWrapper'
+)(PaddedView);
+
+const SecondaryActionIcon = withTheme(
+  ({ theme }) => ({
+    name: 'info',
+    fill: theme.colors.text.secondary,
+  }),
+  'ui-prayer.PrayerScreen.SecondaryActionIcon'
+)(Icon);
+
 const PrayerScreen = ({
-  primaryActionText,
   children,
   isLoading,
   onPressBackground,
   onPressPrimary,
+  onPressSecondary,
+  primaryActionText,
+  secondaryActionText,
 }) => (
   <FlexedKeyboardAvoidingView behavior={'padding'}>
     <FlexedScrollView>
@@ -57,7 +77,15 @@ const PrayerScreen = ({
           <Content>{children}</Content>
         </FlexedTouchable>
         <PaddedView>
-          <ButtonWithProps
+          {onPressSecondary ? (
+            <SecondaryActionWrapper>
+              <SecondaryAction onPress={onPressSecondary}>
+                <SecondaryActionIcon />
+                {secondaryActionText}
+              </SecondaryAction>
+            </SecondaryActionWrapper>
+          ) : null}
+          <PrimaryButton
             onPress={onPressPrimary}
             title={primaryActionText}
             isLoading={isLoading}
@@ -69,16 +97,19 @@ const PrayerScreen = ({
 );
 
 PrayerScreen.propTypes = {
-  primaryActionText: PropTypes.string,
   children: PropTypes.node,
   isLoading: PropTypes.bool,
   onPressBackground: PropTypes.func,
   onPressPrimary: PropTypes.func,
+  onPressSecondary: PropTypes.func,
+  primaryActionText: PropTypes.string,
+  secondaryActionText: PropTypes.string,
 };
 
 PrayerScreen.defaultProps = {
-  primaryActionText: 'Pray',
   onPressBackground: () => Keyboard.dismiss(),
+  primaryActionText: 'Pray',
+  secondaryActionText: 'How to Pray',
 };
 
 export default withIsLoading(PrayerScreen);

--- a/packages/apollos-ui-prayer/src/PrayerScreen/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/index.js
@@ -43,11 +43,17 @@ const FlexedScrollView = withTheme(
   'ui-prayer.PrayerScreen.FlexedScrollView'
 )(ScrollView);
 
-const PrayerScreen = ({ buttonText, children, isLoading, onPressButton }) => (
+const PrayerScreen = ({
+  buttonText,
+  children,
+  isLoading,
+  onPressBackground,
+  onPressButton,
+}) => (
   <FlexedKeyboardAvoidingView behavior={'padding'}>
     <FlexedScrollView>
       <FlexedSafeAreaView>
-        <FlexedTouchable onPress={() => Keyboard.dismiss()}>
+        <FlexedTouchable onPress={onPressBackground}>
           <Content>{children}</Content>
         </FlexedTouchable>
         <PaddedView>
@@ -66,11 +72,13 @@ PrayerScreen.propTypes = {
   buttonText: PropTypes.string,
   children: PropTypes.node,
   isLoading: PropTypes.bool,
+  onPressBackground: PropTypes.func,
   onPressButton: PropTypes.func,
 };
 
 PrayerScreen.defaultProps = {
   buttonText: 'Pray',
+  onPressBackground: () => Keyboard.dismiss(),
 };
 
 export default withIsLoading(PrayerScreen);

--- a/packages/apollos-ui-prayer/src/PrayerScreen/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/index.js
@@ -48,7 +48,7 @@ const PrayerScreen = ({
   children,
   isLoading,
   onPressBackground,
-  onPressButton,
+  onPressPrimary,
 }) => (
   <FlexedKeyboardAvoidingView behavior={'padding'}>
     <FlexedScrollView>
@@ -58,8 +58,8 @@ const PrayerScreen = ({
         </FlexedTouchable>
         <PaddedView>
           <ButtonWithProps
-            onPress={onPressButton}
             title={buttonText}
+            onPress={onPressPrimary}
             isLoading={isLoading}
           />
         </PaddedView>
@@ -73,7 +73,7 @@ PrayerScreen.propTypes = {
   children: PropTypes.node,
   isLoading: PropTypes.bool,
   onPressBackground: PropTypes.func,
-  onPressButton: PropTypes.func,
+  onPressPrimary: PropTypes.func,
 };
 
 PrayerScreen.defaultProps = {

--- a/packages/apollos-ui-prayer/src/PrayerScreen/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/index.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import {
   Button,
   ButtonText,
+  Icon,
   PaddedView,
   styled,
   withIsLoading,

--- a/packages/apollos-ui-prayer/src/PrayerScreen/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerScreen/index.js
@@ -44,7 +44,7 @@ const FlexedScrollView = withTheme(
 )(ScrollView);
 
 const PrayerScreen = ({
-  buttonText,
+  primaryActionText,
   children,
   isLoading,
   onPressBackground,
@@ -58,8 +58,8 @@ const PrayerScreen = ({
         </FlexedTouchable>
         <PaddedView>
           <ButtonWithProps
-            title={buttonText}
             onPress={onPressPrimary}
+            title={primaryActionText}
             isLoading={isLoading}
           />
         </PaddedView>
@@ -69,7 +69,7 @@ const PrayerScreen = ({
 );
 
 PrayerScreen.propTypes = {
-  buttonText: PropTypes.string,
+  primaryActionText: PropTypes.string,
   children: PropTypes.node,
   isLoading: PropTypes.bool,
   onPressBackground: PropTypes.func,
@@ -77,7 +77,7 @@ PrayerScreen.propTypes = {
 };
 
 PrayerScreen.defaultProps = {
-  buttonText: 'Pray',
+  primaryActionText: 'Pray',
   onPressBackground: () => Keyboard.dismiss(),
 };
 


### PR DESCRIPTION
## DESCRIPTION
Adds an `onPressBackground` prop to the `PrayerScreen` component.

### What does this PR do, or why is it needed?
This allows us to pass `null` to `onPressBackground` to disabled the "background" `Touchable` we currently use to dismiss the keyboard.

### What design trade-offs/decisions were made?
The other option was to duplicate this component and remove a few unnecessary components. That felt unnecessary.
### How do I test this PR?
Stories, test, oh my!

### What automated tests did you write?
100% covered.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
