### PR TITLE
Fix issue where re-renders aren't picked up in StretchyView

### DIFF
--- a/packages/apollos-ui-kit/src/StretchyView/StretchyView.stories.js
+++ b/packages/apollos-ui-kit/src/StretchyView/StretchyView.stories.js
@@ -1,7 +1,7 @@
 /* eslint-disable react-native/no-inline-styles */
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@apollosproject/ui-storybook';
-import { StyleSheet, ScrollView, View } from 'react-native';
+import { StyleSheet, Animated, View } from 'react-native';
 import {
   ConnectedImage,
   GradientOverlayImage,
@@ -9,11 +9,54 @@ import {
   H1,
   H2,
   H3,
+  Button,
 } from '@apollosproject/ui-kit';
 
 import StretchyView from '.';
 
+const { ScrollView } = Animated;
+
 const imageStyle = { width: '100%', aspectRatio: 1 };
+
+const HeaderStory = () => {
+  const [i, setSource] = useState(342);
+  const uri = `https://picsum.photos/id/${i}/600/600`;
+  return (
+    <StretchyView>
+      {({ Stretchy, ...scrollViewProps }) => (
+        <ScrollView {...scrollViewProps}>
+          <View>
+            <Stretchy>
+              <ConnectedImage style={imageStyle} source={{ uri }} />
+            </Stretchy>
+            <View
+              style={{
+                ...StyleSheet.absoluteFillObject,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <H2>Text on top of the stretchy!</H2>
+              <Button
+                onPress={() => setSource(i + 1)}
+                title="Change header image"
+              />
+            </View>
+          </View>
+          <PaddedView>
+            <H1 padded>Well hello there!</H1>
+            <H2 padded>
+              Hello there!
+              {'\n'}
+            </H2>
+            <H3 padded>Hello there!</H3>
+            <H1 padded>Try to scroll me around.</H1>
+          </PaddedView>
+        </ScrollView>
+      )}
+    </StretchyView>
+  );
+};
 
 storiesOf('StretchyView', module)
   .add('stretchy as a background', () => (
@@ -41,40 +84,7 @@ storiesOf('StretchyView', module)
       )}
     </StretchyView>
   ))
-  .add('stretchy as a header', () => (
-    <StretchyView>
-      {({ Stretchy, ...scrollViewProps }) => (
-        <ScrollView {...scrollViewProps}>
-          <View>
-            <Stretchy>
-              <ConnectedImage
-                style={imageStyle}
-                source={{ uri: 'https://picsum.photos/id/342/600/600' }}
-              />
-            </Stretchy>
-            <View
-              style={{
-                ...StyleSheet.absoluteFillObject,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <H2>Text on top of the stretchy!</H2>
-            </View>
-          </View>
-          <PaddedView>
-            <H1 padded>Well hello there!</H1>
-            <H2 padded>
-              Hello there!
-              {'\n'}
-            </H2>
-            <H3 padded>Hello there!</H3>
-            <H1 padded>Try to scroll me around.</H1>
-          </PaddedView>
-        </ScrollView>
-      )}
-    </StretchyView>
-  ))
+  .add('stretchy as a header', () => <HeaderStory />)
   .add('stretchy as a footer', () => (
     <StretchyView>
       {({ Stretchy, ...scrollViewProps }) => (


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

If you've ever noticed a bug in our apps where pulling down on a content-item causes the cover image to flash to gray - this fixes it!

This issue is caused by re-renders to the children you pass to `<Stretchy>` are not picked up. I hacked together a "clever" solution using `useEffect` and a deep-comparison on `children` to mitigate. It's....not super clean but it is succinct and I think fairly stable.

### What design trade-offs/decisions were made?

Before:

![ezgif com-optimize (1)](https://user-images.githubusercontent.com/103927/86313588-1b6c1c00-bbeb-11ea-9e4a-49860ca0df78.gif)

After:

![ezgif com-optimize (2)](https://user-images.githubusercontent.com/103927/86313590-1d35df80-bbeb-11ea-8a50-bcf66da2ef4c.gif)


### How do I test this PR?

Check out the story! Press the button.

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
