### PR TITLE
Aligns eslint web rules with core

### DIFF
--- a/packages/apollos-eslint-config/web.js
+++ b/packages/apollos-eslint-config/web.js
@@ -31,6 +31,7 @@ module.exports = {
     'react/jsx-filename-extension': 0,
     'react/jsx-handler-names': 2,
     'react/jsx-curly-brace-presence': 0,
+    'react/jsx-props-no-spreading': 0,
     'react/prefer-stateless-function': [2, { ignorePureComponents: true }],
     'react/require-default-props': 0,
     'react/prop-types': ['error', { ignore: ['navigation'] }],


### PR DESCRIPTION
### What does this PR do, or why is it needed?
The rule ` react/jsx-props-no-spreading` is either new or broken on for react native. I noticed it was throwing lots of errors on the web though. Either way we spread props in our library code a lot. So I'm turning it off on web for congruency. 

### What design trade-offs/decisions were made?
N/A
### How do I test this PR?
N/A
### What automated tests did you write?
N/A
## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
