### PR TITLE
Ui-auth override names

### DIFF
--- a/packages/apollos-ui-auth/src/BackButton.js
+++ b/packages/apollos-ui-auth/src/BackButton.js
@@ -19,9 +19,12 @@ const SuppressingView = styled(
   'ui-auth.BackButton.SuppressingView'
 )(View);
 
-const Button = withTheme(({ theme }) => ({
-  borderRadius: theme.sizing.baseBorderRadius,
-}))(Touchable);
+const Button = withTheme(
+  ({ theme }) => ({
+    borderRadius: theme.sizing.baseBorderRadius,
+  }),
+  'ui-auth.BackButton.Button'
+)(Touchable);
 
 const ButtonWrapper = styled(
   {
@@ -31,13 +34,16 @@ const ButtonWrapper = styled(
   'ui-auth.BackButton.ButtonWrapper'
 )(PaddedView);
 
-const BackButtonIcon = withTheme(({ theme }) => ({
-  fill: theme.colors.action.secondary,
-  size: theme.sizing.baseUnit * 1.5,
-  style: {
-    paddingRight: 0,
-  },
-}))(Icon);
+const BackButtonIcon = withTheme(
+  ({ theme }) => ({
+    fill: theme.colors.action.secondary,
+    size: theme.sizing.baseUnit * 1.5,
+    style: {
+      paddingRight: 0,
+    },
+  }),
+  'ui-auth.BackButton.BackButtonIcon'
+)(Icon);
 
 const BackButton = ({ onPress }) => (
   <SuppressingView>

--- a/packages/apollos-ui-auth/src/Entry.js
+++ b/packages/apollos-ui-auth/src/Entry.js
@@ -31,10 +31,13 @@ import {
   TitleText,
 } from './styles';
 
-const FullScreenGradientBackground = styled({
-  ...StyleSheet.absoluteFillObject,
-  resizeMode: 'cover',
-})(BackgroundView);
+const FullScreenGradientBackground = styled(
+  {
+    ...StyleSheet.absoluteFillObject,
+    resizeMode: 'cover',
+  },
+  'ui-auth.Entry.FullScreenGradientBackground'
+)(BackgroundView);
 
 const Entry = ({
   BackgroundComponent,

--- a/packages/apollos-ui-auth/src/Header.js
+++ b/packages/apollos-ui-auth/src/Header.js
@@ -1,12 +1,15 @@
 import { SafeAreaView } from 'react-native';
 import { styled } from '@apollosproject/ui-kit';
 
-const Header = styled(({ theme }) => ({
-  padding: theme.sizing.baseUnit,
-  paddingBottom: theme.sizing.baseUnit * 1.5,
-  flexDirection: 'row',
-  alignItems: 'center',
-  backgroundColor: theme.colors.background.paper,
-}))(SafeAreaView);
+const Header = styled(
+  ({ theme }) => ({
+    padding: theme.sizing.baseUnit,
+    paddingBottom: theme.sizing.baseUnit * 1.5,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.colors.background.paper,
+  }),
+  'ui-auth.Header'
+)(SafeAreaView);
 
 export default Header;

--- a/packages/apollos-ui-auth/src/styles.js
+++ b/packages/apollos-ui-auth/src/styles.js
@@ -28,22 +28,25 @@ import {
 import BackButton from './BackButton';
 
 const FlexedSafeAreaView = compose(
-  styled({ height: '100%' }, 'ui-auth.FlexedSafeAreaView'),
+  styled({ height: '100%' }, 'ui-auth.styles.FlexedSafeAreaView'),
   withProps({ forceInset: { top: 'always' } })
 )(SafeAreaView);
 
-const BrandIcon = withTheme(({ theme }) => ({
-  name: 'brand-icon',
-  size: theme.sizing.baseUnit * 3.0,
-  fill: theme.colors.text.primary,
-  marginBottom: theme.sizing.baseUnit,
-}))(Icon);
+const BrandIcon = withTheme(
+  ({ theme }) => ({
+    name: 'brand-icon',
+    size: theme.sizing.baseUnit * 3.0,
+    fill: theme.colors.text.primary,
+    marginBottom: theme.sizing.baseUnit,
+  }),
+  'ui-auth.styles.BrandIcon'
+)(Icon);
 
 const TitleText = styled(
   ({ theme }) => ({
     color: theme.colors.action.primary,
   }),
-  'ui-auth.TitleText'
+  'ui-auth.styles.TitleText'
 )(H2);
 
 const PromptText = styled(
@@ -51,7 +54,7 @@ const PromptText = styled(
     color: theme.colors.text.primary,
     paddingBottom: theme.sizing.baseUnit * 1.5,
   }),
-  'ui-auth.PromptText'
+  'ui-auth.styles.PromptText'
 )(H5);
 
 const LegalText = styled(
@@ -59,7 +62,7 @@ const LegalText = styled(
     color: theme.colors.text.tertiary,
     fontWeight: 'normal',
   }),
-  'ui-auth.EmailEntry.LegalText'
+  'ui-auth.styles.LegalText'
 )(H6);
 
 // Tab Login
@@ -70,7 +73,7 @@ const TabWrapper = styled(
     marginVertical: 0,
     ...Platform.select(theme.shadows.default),
   }),
-  'ui-auth.TabWrapper'
+  'ui-auth.styles.TabWrapper'
 )(Card);
 
 const TabContainer = styled(
@@ -78,11 +81,13 @@ const TabContainer = styled(
     flexDirection: alternateLogin ? 'row-reverse' : 'row',
     flex: 1,
   }),
-  'ui-auth.TabContainer'
+  'ui-auth.styles.TabContainer'
 )(View);
 
 // We need a wrapping `View` because this style doesn't work when applied to a `Touchable` on android.
-const TabButtonWrapper = styled({ flex: 1 }, 'ui-auth.TabButtonWrapper')(View);
+const TabButtonWrapper = styled({ flex: 1 }, 'ui-auth.styles.TabButtonWrapper')(
+  View
+);
 
 const TabButton = styled(
   ({ theme, isActive }) => ({
@@ -100,12 +105,15 @@ const TabButton = styled(
 
     ...Platform.select(theme.shadows.none),
   }),
-  'ui-auth.TabButton'
+  'ui-auth.styles.TabButton'
 )(View);
 
-const TabButtonText = styled(({ theme, isActive }) => ({
-  color: isActive ? theme.colors.text.primary : theme.colors.text.tertiary,
-}))(UIText);
+const TabButtonText = styled(
+  ({ theme, isActive }) => ({
+    color: isActive ? theme.colors.text.primary : theme.colors.text.tertiary,
+  }),
+  'ui-auth.styles.TabButtonText'
+)(UIText);
 
 const TabCard = styled(
   ({ theme }) => ({
@@ -116,7 +124,7 @@ const TabCard = styled(
     marginVertical: 0,
     ...Platform.select(theme.shadows.none),
   }),
-  'ui-auth.TabCard'
+  'ui-auth.styles.TabCard'
 )(Card);
 
 const FieldLabel = styled(
@@ -125,7 +133,7 @@ const FieldLabel = styled(
     opacity: 0.7,
     ...(padded ? { marginTop: theme.sizing.baseUnit } : {}),
   }),
-  'ui-auth.FieldLabel'
+  'ui-auth.styles.FieldLabel'
 )(H6);
 
 const DatePicker = styled(
@@ -133,7 +141,7 @@ const DatePicker = styled(
     marginTop: 0,
     marginBottom: theme.sizing.baseUnit,
   }),
-  'ui-auth.DatePicker'
+  'ui-auth.styles.DatePicker'
 )(DateInput);
 
 const RadioInput = styled(
@@ -143,14 +151,14 @@ const RadioInput = styled(
     alignItems: 'center',
     flexWrap: 'wrap',
   }),
-  'ui-auth.RadioInput'
+  'ui-auth.styles.RadioInput'
 )(Radio);
 
 const RadioLabel = styled(
   ({ theme }) => ({
     marginLeft: theme.sizing.baseUnit * 0.5,
   }),
-  'ui-auth.RadioLabel'
+  'ui-auth.styles.RadioLabel'
 )(H5);
 
 const ProfileEntryFieldContainer = ({


### PR DESCRIPTION
The purpose of this PR is to make sure all instances of using `withTheme` and `styled` in core's ui-auth package provides a named override. With "names", church apps are able to override that component's style. For example:

```
const MyButtonOnCore = styled({
   backgroundColor: 'green',
}, 'MyButtonOnCore')(Button);

```
And then in an app's overrides, you could override that button's styles:

```
const overrides = {
  'MyButtonOnCore': {
    backgroundColor: 'red',
  }
}
```