### PR TITLE
Ui-connected override names

### DIFF
--- a/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/index.js
+++ b/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/index.js
@@ -9,16 +9,26 @@ const Title = styled(
   ({ theme }) => ({
     color: theme.colors.text.tertiary,
   }),
-  'ActionListFeature.Title'
+  'ui-connected.ActionListFeatureConnected.ActionListFeature.Title'
 )(H6);
 
-const Subtitle = styled({}, 'ActionListFeature.Subtitle')(H3);
+const Subtitle = styled(
+  {},
+  'ui-connected.ActionListFeatureConnected.ActionListFeature.Subtitle'
+)(H3);
 
-const ActionListHeader = styled(({ theme: { sizing: { baseUnit } } }) => ({
-  paddingHorizontal: baseUnit,
-  paddingTop: baseUnit,
-  // Padding Bottom is baked into the card content
-}))(View);
+const ActionListHeader = styled(
+  ({
+    theme: {
+      sizing: { baseUnit },
+    },
+  }) => ({
+    paddingHorizontal: baseUnit,
+    paddingTop: baseUnit,
+    // Padding Bottom is baked into the card content
+  }),
+  'ui-connected.ActionListFeatureConnected.ActionListFeature.ActionListHeader'
+)(View);
 
 const loadingStateArray = [
   {

--- a/packages/apollos-ui-connected/src/CampaignItemListFeature/index.js
+++ b/packages/apollos-ui-connected/src/CampaignItemListFeature/index.js
@@ -19,15 +19,20 @@ const Title = styled(
   ({ theme }) => ({
     color: theme.colors.text.tertiary,
   }),
-  'CampaignItemListFeature.Title'
+  'ui-connected.CampaignListFeature.Title'
 )(H5);
 
-const Subtitle = styled({}, 'CampaignItemListFeature.Subtitle')(H2);
+const Subtitle = styled({}, 'ui-connected.CampaignItemListFeature.Subtitle')(
+  H2
+);
 
-const Header = styled(({ theme }) => ({
-  paddingTop: theme.sizing.baseUnit * 3,
-  paddingBottom: theme.sizing.baseUnit * 0.5,
-}))(PaddedView);
+const Header = styled(
+  ({ theme }) => ({
+    paddingTop: theme.sizing.baseUnit * 3,
+    paddingBottom: theme.sizing.baseUnit * 0.5,
+  }),
+  'ui-connected.CampaignItemListFeature.Header'
+)(PaddedView);
 
 const ListItemComponent = ({ contentId, labelText, ...item }) => (
   <LiveConsumer contentId={contentId}>

--- a/packages/apollos-ui-connected/src/ContentCardConnected/ContentCardComponentMapper/index.js
+++ b/packages/apollos-ui-connected/src/ContentCardConnected/ContentCardComponentMapper/index.js
@@ -7,7 +7,7 @@ import cardMapper from './cardMapper';
 
 const ContentCardComponentMapper = withTheme(
   () => ({}),
-  'ContentCardComponentMapper'
+  'ui-connected.ContentCardConnected.ContentCardComponentMapper'
 )(({ Component, ...props }) => <Component {...props} />);
 
 ContentCardComponentMapper.propTypes = {

--- a/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/WebviewFeature.js
+++ b/packages/apollos-ui-connected/src/ContentSingleFeaturesConnected/WebviewFeature.js
@@ -15,14 +15,14 @@ const StyledCard = styled(
     overflow: 'hidden',
     ...Platform.select(theme.shadows.default),
   }),
-  'ui-connected.WebviewFeature.StyledCard'
+  'ui-connected.ContentSingleFeaturesConnected.WebviewFeature.StyledCard'
 )(View);
 
 const StyledWebView = styled(
   () => ({
     flex: 1,
   }),
-  'ui-connected.WebviewFeature.StyledWebView'
+  'ui-connected.ContentSingleFeaturesConnected.WebviewFeature.StyledWebView'
 )(WebView);
 
 const StyledH3 = styled(
@@ -30,7 +30,7 @@ const StyledH3 = styled(
     paddingHorizontal: theme.sizing.baseUnit,
     color: theme.colors.screen,
   }),
-  'ui-connected.WebviewFeature.StyledH3'
+  'ui-connected.ContentSingleFeaturesConnected.WebviewFeature.StyledH3'
 )(H3);
 
 const StyledText = styled(
@@ -38,14 +38,14 @@ const StyledText = styled(
     color: theme.colors.secondary,
     paddingHorizontal: theme.sizing.baseUnit,
   }),
-  'ui-connected.WebviewFeature.StyledText'
+  'ui-connected.ContentSingleFeaturesConnected.WebviewFeature.StyledText'
 )(UIText);
 
 const StyledSideBySideView = styled(
   () => ({
     alignItems: 'center',
   }),
-  'ui-connected.WebviewFeature.StyledSideBySideView'
+  'ui-connected.ContentSingleFeaturesConnected.WebviewFeature.StyledSideBySideView'
 )(SideBySideView);
 
 const WebviewFeature = ({ url, title, linkText, height }) => (

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/index.js
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/index.js
@@ -12,19 +12,25 @@ import {
 } from '@apollosproject/ui-kit';
 import { LiveConsumer } from '../..';
 
-const Header = styled(({ theme }) => ({
-  paddingTop: theme.sizing.baseUnit * 3,
-  paddingBottom: 0,
-}))(PaddedView);
+const Header = styled(
+  ({ theme }) => ({
+    paddingTop: theme.sizing.baseUnit * 3,
+    paddingBottom: 0,
+  }),
+  'ui-connected.HeroListFeatureConnected.HeroListFeature.Header'
+)(PaddedView);
 
 const Title = styled(
   ({ theme }) => ({
     color: theme.colors.text.tertiary,
   }),
-  'HeroListFeature.Title'
+  'ui-connected.HeroListFeatureConnected.HeroListFeature.Title'
 )(H6);
 
-const Subtitle = styled({}, 'HeroListFeature.Subtitle')(H3);
+const Subtitle = styled(
+  {},
+  'ui-connected.HeroListFeatureConnected.HeroListFeature.Subtitle'
+)(H3);
 
 const loadingStateArray = [
   {

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/index.js
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/index.js
@@ -18,15 +18,21 @@ const Title = styled(
   ({ theme }) => ({
     color: theme.colors.text.tertiary,
   }),
-  'HorizontalCardListFeature.Title'
+  'ui-connected.HorizontalCardListFeatureConnected.HorizontalCardListFeature.Title'
 )(H5);
 
-const Subtitle = styled({}, 'HorizontalCardListFeature.Subtitle')(H2);
+const Subtitle = styled(
+  {},
+  'ui-connected.HorizontalCardListFeatureConnected.HorizontalCardListFeature.Subtitle'
+)(H2);
 
-const Header = styled(({ theme }) => ({
-  paddingTop: theme.sizing.baseUnit * 3,
-  paddingBottom: theme.sizing.baseUnit * 0.5,
-}))(PaddedView);
+const Header = styled(
+  ({ theme }) => ({
+    paddingTop: theme.sizing.baseUnit * 3,
+    paddingBottom: theme.sizing.baseUnit * 0.5,
+  }),
+  'ui-connected.HorizontalCardListFeatureConnected.HorizontalCardListFeature.Header'
+)(PaddedView);
 
 class HorizontalCardListFeature extends PureComponent {
   static defaultProps = {

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/index.js
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/index.js
@@ -18,35 +18,50 @@ import {
 
 import HorizontalContentCardConnected from '../../HorizontalContentCardConnected';
 
-const RowHeader = styled(({ theme }) => ({
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  zIndex: 2, // UX hack to improve tapability. Positions RowHeader above StyledHorizontalTileFeed
-  paddingTop: theme.sizing.baseUnit * 0.5,
-  paddingLeft: theme.sizing.baseUnit,
-}))(View);
+const RowHeader = styled(
+  ({ theme }) => ({
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    zIndex: 2, // UX hack to improve tapability. Positions RowHeader above StyledHorizontalTileFeed
+    paddingTop: theme.sizing.baseUnit * 0.5,
+    paddingLeft: theme.sizing.baseUnit,
+  }),
+  'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.RowHeader'
+)(View);
 
-const Name = styled({
-  flexGrow: 2,
-})(View);
+const Name = styled(
+  {
+    flexGrow: 2,
+  },
+  'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.Name'
+)(View);
 
-const ButtonLinkSpacing = styled(({ theme }) => ({
-  flexDirection: 'row', // correctly positions the loading state
-  justifyContent: 'flex-end', // correctly positions the loading state
-  padding: theme.sizing.baseUnit, // UX hack to improve tapability.
-}))(View);
+const ButtonLinkSpacing = styled(
+  ({ theme }) => ({
+    flexDirection: 'row', // correctly positions the loading state
+    justifyContent: 'flex-end', // correctly positions the loading state
+    padding: theme.sizing.baseUnit, // UX hack to improve tapability.
+  }),
+  'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.ButtonLinkSpacing'
+)(View);
 
-const AndroidTouchableFix = withTheme(({ theme }) => ({
-  borderRadius: theme.sizing.baseBorderRadius / 2,
-}))(Touchable);
+const AndroidTouchableFix = withTheme(
+  ({ theme }) => ({
+    borderRadius: theme.sizing.baseBorderRadius / 2,
+  }),
+  'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.AndroidTouchableFix'
+)(Touchable);
 
-const StyledHorizontalTileFeed = styled(({ theme }) => ({
-  /* UX hack to improve tapability. The magic number below happens to be the number of pixels that
-   * aligns everything in the same place as if none of the UX hacks were there. */
-  marginTop: theme.sizing.baseUnit * -1.25,
-  zIndex: 1,
-}))(HorizontalTileFeed);
+const StyledHorizontalTileFeed = styled(
+  ({ theme }) => ({
+    /* UX hack to improve tapability. The magic number below happens to be the number of pixels that
+     * aligns everything in the same place as if none of the UX hacks were there. */
+    marginTop: theme.sizing.baseUnit * -1.25,
+    zIndex: 1,
+  }),
+  'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.StyledHorizontalTileFeed'
+)(HorizontalTileFeed);
 
 class HorizontalLikedContentFeed extends Component {
   static propTypes = {

--- a/packages/apollos-ui-connected/src/LikeButtonConnected/LikeButton/index.js
+++ b/packages/apollos-ui-connected/src/LikeButtonConnected/LikeButton/index.js
@@ -10,7 +10,8 @@ const LikeIcon = withTheme(
   ({ theme: { colors: { secondary } = {} } = {}, isLiked } = {}) => ({
     name: isLiked ? 'like-solid' : 'like',
     fill: secondary,
-  })
+  }),
+  'ui-connected.LikeButtonConnected.LikeButton.LikeIcon'
 )(Icon);
 
 LikeIcon.propTypes = {

--- a/packages/apollos-ui-connected/src/MediaControlsConnected/PlayButtonConnected/PlayButton.js
+++ b/packages/apollos-ui-connected/src/MediaControlsConnected/PlayButtonConnected/PlayButton.js
@@ -11,13 +11,19 @@ import {
   H6,
 } from '@apollosproject/ui-kit';
 
-const Container = styled({
-  flexDirection: 'row',
-  alignItems: 'flex-start',
-  justifyContent: 'flex-start',
-})(View);
+const Container = styled(
+  {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+  'ui-connected.MediaControlsConnected.PlayButtonConnected.PlayButton.Container'
+)(View);
 
-const StyledMediaThumbnail = styled({ marginVertical: 0 })(MediaThumbnail);
+const StyledMediaThumbnail = styled(
+  { marginVertical: 0 },
+  'ui-connected.MediaControlsConnected.PlayButtonConnected.PlayButton.StyledMediaThumbnail'
+)(MediaThumbnail);
 
 const PlayButton = ({ coverImageSources, icon, onPress, title, ...props }) => (
   <Container {...props}>

--- a/packages/apollos-ui-connected/src/ShareButtonConnected/ShareButton/index.js
+++ b/packages/apollos-ui-connected/src/ShareButtonConnected/ShareButton/index.js
@@ -2,9 +2,12 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { Touchable, Icon, withTheme } from '@apollosproject/ui-kit';
 
-const ShareIcon = withTheme(({ theme }) => ({
-  fill: theme.colors.secondary,
-}))(Icon);
+const ShareIcon = withTheme(
+  ({ theme }) => ({
+    fill: theme.colors.secondary,
+  }),
+  'ui-connected.ShareButtonConnected.ShareButton.ShareIcon'
+)(Icon);
 
 const ShareButton = memo(({ onPress }) => (
   <Touchable onPress={onPress}>

--- a/packages/apollos-ui-connected/src/UserAvatarConnected/UserAvatarUpdate/UserAvatarUpdate.js
+++ b/packages/apollos-ui-connected/src/UserAvatarConnected/UserAvatarUpdate/UserAvatarUpdate.js
@@ -9,10 +9,13 @@ import UserAvatarConnected from '../UserAvatarConnected';
 
 import uploadPhoto from '../../utils/uploadPhoto';
 
-const Wrapper = styled({
-  justifyContent: 'center',
-  alignItems: 'center',
-})(View);
+const Wrapper = styled(
+  {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  'ui-connected.UserAvatarConnected.UserAvatarUpdate.UserAvatarUpdate.Wrapper'
+)(View);
 
 class UserAvatarUpdate extends PureComponent {
   static propTypes = {

--- a/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/index.js
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/index.js
@@ -17,15 +17,21 @@ const Title = styled(
   ({ theme }) => ({
     color: theme.colors.text.tertiary,
   }),
-  'VerticalCardListFeature.Title'
+  'ui-connected.VerticalCardListFeatureConnected.VerticalCardListFeature.Title'
 )(H5);
 
-const Subtitle = styled({}, 'VerticalCardListFeature.Subtitle')(H2);
+const Subtitle = styled(
+  {},
+  'ui-connected.VerticalCardListFeatureConnected.VerticalCardListFeature.Subtitle'
+)(H2);
 
-const Header = styled(({ theme }) => ({
-  paddingTop: theme.sizing.baseUnit * 3,
-  paddingBottom: theme.sizing.baseUnit * 0.5,
-}))(PaddedView);
+const Header = styled(
+  ({ theme }) => ({
+    paddingTop: theme.sizing.baseUnit * 3,
+    paddingBottom: theme.sizing.baseUnit * 0.5,
+  }),
+  'ui-connected.VerticalCardListFeatureConnected.VerticalCardListFeature.Header'
+)(PaddedView);
 
 // const getContent = ({ cards, isLoading }) => {
 //   let content = [];


### PR DESCRIPTION
The purpose of this PR is to make sure all instances of using `withTheme` and `styled` in core's ui-connected package provides a named override. With "names", church apps are able to override that component's style. For example:

```
const MyButtonOnCore = styled({
   backgroundColor: 'green',
}, 'MyButtonOnCore')(Button);

```
And then in an app's overrides, you could override that button's styles:

```
const overrides = {
  'MyButtonOnCore': {
    backgroundColor: 'red',
  }
}
```