### PR TITLE
Pass down isFeatured prop so CardMapper can identify FeaturedCards

### DIFF
--- a/packages/apollos-ui-connected/src/CampaignItemListFeature/index.js
+++ b/packages/apollos-ui-connected/src/CampaignItemListFeature/index.js
@@ -47,6 +47,7 @@ const ListItemComponent = ({ contentId, labelText, ...item }) => (
               }
             : { isLive, labelText })} // we only want to pass `labelText` if we are NOT live. If we do we will override the default logic in the FeaturedCard
           {...item}
+          isFeatured
         />
       );
     }}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The funny thing is, this PR might completely eliminate the need to have the `CampaignCards` long term, we could have the CardMapper look at `isFeatured` instead. 

For what it's worth, we are doing this on Grace in order to use both a custom mapper and FeaturedCards

https://github.com/Differential/grace-apollos-app/commit/110e453015e0e9bf93bd8ab4187ee38a212a0e82#diff-33281eb9f3d40f3dcfa35a784630e994L14

https://github.com/Differential/grace-apollos-app/commit/110e453015e0e9bf93bd8ab4187ee38a212a0e82#diff-620a567ff291d601c67a71ba9238435dR47

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
