### PR TITLE
feat: Show dates on content

### DIFF
--- a/local.graphql
+++ b/local.graphql
@@ -126,6 +126,7 @@ type ContentChannel implements Node {
 interface ContentItem {
   id: ID!
   title(hyphenated: Boolean): String
+  publishDate: String
   coverImage: ImageMedia
   images: [ImageMedia]
   videos: [VideoMedia]
@@ -163,6 +164,7 @@ input ContentItemsConnectionInput {
 type ContentSeriesContentItem implements ContentItem & Node {
   id: ID!
   title(hyphenated: Boolean): String
+  publishDate: String
   coverImage: ImageMedia
   images: [ImageMedia]
   videos: [VideoMedia]
@@ -194,6 +196,7 @@ type Device implements Node {
 type DevotionalContentItem implements ContentItem & Node {
   id: ID!
   title(hyphenated: Boolean): String
+  publishDate: String
   coverImage: ImageMedia
   images: [ImageMedia]
   videos: [VideoMedia]
@@ -310,6 +313,7 @@ interface Media {
 type MediaContentItem implements ContentItem & Node {
   id: ID!
   title(hyphenated: Boolean): String
+  publishDate: String
   coverImage: ImageMedia
   images: [ImageMedia]
   videos: [VideoMedia]
@@ -538,6 +542,7 @@ enum ThemeType {
 type UniversalContentItem implements ContentItem & Node {
   id: ID!
   title(hyphenated: Boolean): String
+  publishDate: String
   coverImage: ImageMedia
   images: [ImageMedia]
   videos: [VideoMedia]
@@ -600,6 +605,7 @@ type VideoMediaSource implements MediaSource {
 type WeekendContentItem implements ContentItem & Node {
   id: ID!
   title(hyphenated: Boolean): String
+  publishDate: String
   coverImage: ImageMedia
   images: [ImageMedia]
   videos: [VideoMedia]

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -180,6 +180,14 @@ export default class ContentItem extends RockApolloDataSource {
     return features;
   }
 
+getPublishDate = ({
+  content,
+  attributeValues
+}) => {
+  const publishDate =
+    get(node, 'publishDate', '') !== '' ?
+    moment(node.publishDate).format(DATE_FORMAT) :
+    moment().format(DATE_FORMAT);
   createSummary = ({ content, attributeValues }) => {
     const summary = get(attributeValues, 'summary.value', '');
     if (summary !== '') return summary;

--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -53,6 +53,8 @@ export const defaultContentItemResolvers = {
   coverImage: (root, args, { dataSources: { ContentItem } }) =>
     ContentItem.getCoverImage(root),
 
+  publishDate: (root, args, { dataSources: { ContentItem } }) =>
+    ContentItem.getPublishDate(root),
   theme: () => null, // todo: integrate themes from Rock
 
   sharing: (root, args, { dataSources: { ContentItem } }) => ({

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -302,6 +302,7 @@ export const contentItemSchema = gql`
   interface ContentItem {
     id: ID!
     title(hyphenated: Boolean): String
+    publishDate: String
     coverImage: ImageMedia
     images: [ImageMedia]
     videos: [VideoMedia]
@@ -323,6 +324,7 @@ export const contentItemSchema = gql`
   type UniversalContentItem implements ContentItem & Node {
     id: ID!
     title(hyphenated: Boolean): String
+    publishDate: String
     coverImage: ImageMedia
     images: [ImageMedia]
     videos: [VideoMedia]
@@ -344,6 +346,7 @@ export const contentItemSchema = gql`
   type DevotionalContentItem implements ContentItem & Node {
     id: ID!
     title(hyphenated: Boolean): String
+    publishDate: String
     coverImage: ImageMedia
     images: [ImageMedia]
     videos: [VideoMedia]
@@ -367,6 +370,7 @@ export const contentItemSchema = gql`
   type MediaContentItem implements ContentItem & Node {
     id: ID!
     title(hyphenated: Boolean): String
+    publishDate: String
     coverImage: ImageMedia
     images: [ImageMedia]
     videos: [VideoMedia]
@@ -390,6 +394,7 @@ export const contentItemSchema = gql`
   type ContentSeriesContentItem implements ContentItem & Node {
     id: ID!
     title(hyphenated: Boolean): String
+    publishDate: String
     coverImage: ImageMedia
     images: [ImageMedia]
     videos: [VideoMedia]
@@ -415,6 +420,7 @@ export const contentItemSchema = gql`
   type WeekendContentItem implements ContentItem & Node {
     id: ID!
     title(hyphenated: Boolean): String
+    publishDate: String
     coverImage: ImageMedia
     images: [ImageMedia]
     videos: [VideoMedia]

--- a/packages/apollos-ui-fragments/src/content.js
+++ b/packages/apollos-ui-fragments/src/content.js
@@ -22,6 +22,7 @@ const CONTENT_ITEM_FRAGMENT = gql`
   fragment contentItemFragment on ContentItem {
     id
     title
+    publishDate
     summary
     htmlContent
     coverImage {
@@ -76,6 +77,7 @@ const CONTENT_CARD_FRAGMENT = gql`
     }
     title
     hyphenatedTitle: title(hyphenated: true)
+    publishDate
     summary
     ... on MediaContentItem {
       videos {
@@ -112,6 +114,7 @@ const CONTENT_MEDIA_FRAGMENT = gql`
   fragment contentMediaFragment on ContentItem {
     id
     title
+    publishDate
     parentChannel {
       id
       name

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,11 +62,6 @@
   dependencies:
     xss "^1.0.6"
 
-"@apollosproject/eslint-config@^1.3.0":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@apollosproject/eslint-config/-/eslint-config-1.4.3.tgz#cd473aa00809aff258917413fcf1ac925934478a"
-  integrity sha512-BgOJa+8h5QD1fOcpShmqiaewltSb64Z2Oj3RbxlB3dmEswDAlCew5djy3CrIu8CLxwUnAFJsuw7FGQ5Tgdmwbw==
-
 "@apollosproject/react-native-airplay-btn@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@apollosproject/react-native-airplay-btn/-/react-native-airplay-btn-0.2.0.tgz#19c1c7154e6c04fd4d5a5587faf6a69cb34d8a79"


### PR DESCRIPTION
## DESCRIPTION
This PR makes it possible to see dates on content items.

### What does this PR do, or why is it needed?
1. Schema update for 'ContentItem' interface now includes publishDate
2. 'content-item' resolver grabs that date from Rock

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
