### PR TITLE
fix: Storybook bringing along RN dep

### DIFF
--- a/ApollosStorybook/metro.config.js
+++ b/ApollosStorybook/metro.config.js
@@ -35,7 +35,7 @@ module.exports = applyConfigForLinkedDependencies(
     },
     {
         projectRoot: __dirname,
-        blacklistLinkedModules: ['react-native', 'react-native-linear-gradient', 'react-native-svg'],
+        blacklistLinkedModules: ['react-native', 'react-native-linear-gradient', 'react-native-svg', '@storybook'],
         resolveNodeModulesAtRoot: true,
     },
 );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Now sure when this started happening, but I've been getting a dependency error in the ApollosStorybook. This change to the `metro.config.js` stops `@storybook` from being loaded multiple times, and that stops `react-native` from being loaded multiple times. 


### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
