### PR TITLE
fix: Adds Auth theme overrides

### DIFF
--- a/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntry.js
+++ b/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntry.js
@@ -2,10 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import moment from 'moment';
-import {
-  RadioButton,
-  withTheme,
-} from '@apollosproject/ui-kit';
+import { RadioButton, withTheme } from '@apollosproject/ui-kit';
 
 import {
   ProfileEntryFieldContainer,

--- a/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntry.js
+++ b/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntry.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import moment from 'moment';
-import { RadioButton } from '@apollosproject/ui-kit';
+import {
+  RadioButton,
+  withTheme,
+} from '@apollosproject/ui-kit';
 
 import {
   ProfileEntryFieldContainer,
@@ -88,4 +91,6 @@ ProfileDetailsEntry.LegalText = LegalText;
 
 ProfileDetailsEntry.displayName = 'ProfileDetailsEntry';
 
-export default ProfileDetailsEntry;
+export default withTheme(() => ({}), 'ui-auth.ProfileDetailsEntry')(
+  ProfileDetailsEntry
+);

--- a/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntryConnected.js
+++ b/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntryConnected.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
 import * as Yup from 'yup';
+import { withTheme } from '@apollosproject/ui-kit';
 
 import { LoginConsumer } from '../LoginProvider';
 import ProfileEntry from './ProfileDetailsEntry';
@@ -61,4 +62,6 @@ ProfileDetailsEntryConnected.defaultProps = {
   Component: ProfileEntry,
 };
 
-export default ProfileDetailsEntryConnected;
+export default withTheme(() => ({}), 'ui-auth.ProfileDetailsEntryConnected')(
+  ProfileDetailsEntryConnected
+);


### PR DESCRIPTION
## DESCRIPTION

This PR adds theme overrides to ProfileDetailsEntry and ProfileDetailsEntryConnected.

### What does this PR do, or why is it needed?

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
