### PR TITLE
fix: Scroll MapView to first campus on load

### DIFF
--- a/packages/apollos-ui-mapview/src/MapView/index.js
+++ b/packages/apollos-ui-mapview/src/MapView/index.js
@@ -112,7 +112,7 @@ class MapView extends Component {
 
   componentDidMount() {
     this.animation.addListener(debounce(this.updateCoordinates));
-    if (this.props.userLocation) {
+    if (this.props.userLocation && this.props.campuses.length) {
       this.updateCoordinates({ value: this.previousScrollPosition }, 500);
     }
   }

--- a/packages/apollos-ui-mapview/src/MapView/index.js
+++ b/packages/apollos-ui-mapview/src/MapView/index.js
@@ -112,17 +112,26 @@ class MapView extends Component {
 
   componentDidMount() {
     this.animation.addListener(debounce(this.updateCoordinates));
+    if (this.props.userLocation) {
+      this.updateCoordinates({ value: this.previousScrollPosition }, 500);
+    }
   }
 
   componentDidUpdate(oldProps) {
-    // update mapview if there are campuses and the location changes
+    // Update the currentCampus state when it comes in from the network.
     if (this.props.currentCampus && !this.state.currentCampus) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ currentCampus: this.props.currentCampus });
     }
+
+    // update mapview if there are campuses and the location changes
+    // or if we loaded in campuses and we already have a user location.
     if (
-      this.props.campuses.length &&
-      oldProps.userLocation !== this.props.userLocation
+      (this.props.campuses.length &&
+        oldProps.userLocation !== this.props.userLocation) ||
+      (this.props.campuses.length &&
+        !oldProps.campuses.length &&
+        this.props.userLocation)
     ) {
       this.updateCoordinates({ value: this.previousScrollPosition });
     }
@@ -145,6 +154,7 @@ class MapView extends Component {
     if (!currentCampus) {
       return campuses;
     }
+
     return [
       campuses.find(({ id }) => id === currentCampus.id),
       ...campuses.filter(({ id }) => id !== currentCampus.id),
@@ -190,11 +200,16 @@ class MapView extends Component {
           : bottomPadding,
     };
 
+    // Either the current campus or the first sorted campus with a geographic location.
     const visibleCampuses = [
-      ...(this.currentCampus ? [this.currentCampus] : this.sortedCampuses),
-    ].filter(
-      ({ latitude, longitude }) => !isNil(latitude) && !isNil(longitude)
-    );
+      ...(this.currentCampus
+        ? [this.currentCampus]
+        : [
+            this.sortedCampuses.filter(
+              ({ latitude, longitude }) => !isNil(latitude) && !isNil(longitude)
+            )[0],
+          ]),
+    ];
 
     if (userLocation) {
       // If we have a user location, we should include it in the current window

--- a/packages/apollos-ui-mapview/src/MapViewConnected/MapViewConnected.stories.js
+++ b/packages/apollos-ui-mapview/src/MapViewConnected/MapViewConnected.stories.js
@@ -1,0 +1,73 @@
+/* eslint-disable react-native/no-inline-styles */
+import React from 'react';
+import { storiesOf } from '@apollosproject/ui-storybook';
+import { ApolloStorybookDecorator } from '@apollosproject/ui-connected/src/testUtils';
+
+import MapViewConnected from '.';
+
+const mocks = {
+  Query: () => ({
+    campuses: () => [
+      {
+        __typename: 'Campus',
+        city: 'Richardson',
+        distanceFromLocation: 100.6461577685534,
+        id: 'Campus:965b6e6d7046a885bea4e300b5c0400d',
+        image: 'https://www.placecage.com/c/220/220',
+        latitude: 32.95103,
+        longitude: -96.74738,
+        name: 'Dallas Campus',
+        postalCode: '75080-5525',
+        state: 'TX',
+        street1: '102 N Weatherred Dr',
+      },
+      {
+        __typename: 'Campus',
+        city: 'Cincinnati',
+        distanceFromLocation: 2037.6461577685534,
+        id: 'Campus:4f68015ba18662a7409d1219a4ce013e',
+        image: 'https://www.placecage.com/c/220/220',
+        latitude: 39.10501,
+        longitude: -84.51138,
+        name: 'Cincinnati Campus',
+        postalCode: '45202-2118',
+        state: 'OH',
+        street1: '120 E 8th St',
+      },
+    ],
+    currentUser: () =>
+      console.log('getting user') || {
+        __typename: 'AuthenticatedUser',
+        id: 'AuthenticatedUser:123',
+        profile: {
+          __typename: 'Person',
+          id: 'Person:123',
+          campus: {
+            __typename: 'Campus',
+            city: 'Richardson',
+            distanceFromLocation: 100.6461577685534,
+            id: 'Campus:965b6e6d7046a885bea4e300b5c0400d',
+            image: 'https://www.placecage.com/c/220/220',
+            latitude: 32.95103,
+            longitude: -96.74738,
+            name: 'Dallas Campus',
+            postalCode: '75080-5525',
+            state: 'TX',
+            street1: '102 N Weatherred Dr',
+          },
+        },
+      },
+  }),
+};
+
+const navigation = {
+  getParam: () => {},
+  navigate: () => {},
+  goBack: () => {},
+};
+
+storiesOf('ui-mapview/MapViewConnected', module)
+  .addDecorator(ApolloStorybookDecorator({ mocks }))
+  .add('default', () => (
+    <MapViewConnected navigation={navigation} onChangeCampus={async () => {}} />
+  ));


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Scrolls the map view to the closest campus on load. 

![2020-09-29 16 25 08](https://user-images.githubusercontent.com/1637694/94612104-a1424680-0270-11eb-9cf8-5a558d6520c8.gif)


### What design trade-offs/decisions were made?

### How do I test this PR?

Best place to test is the new `MapViewConnected` story,

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
