### PR TITLE
fix: Fixes Incorrect Scripture Query

### DIFF
--- a/packages/apollos-data-connector-bible/src/__tests__/__snapshots__/resolver.tests.js.snap
+++ b/packages/apollos-data-connector-bible/src/__tests__/__snapshots__/resolver.tests.js.snap
@@ -14,6 +14,18 @@ Object {
 }
 `;
 
+exports[`Scripture returns a single verse 2`] = `
+Array [
+  "9879dbb7cfe39e4d-01/search?query=SNG.1.1",
+  null,
+  Object {
+    "cacheOptions": Object {
+      "ttl": 86400,
+    },
+  },
+]
+`;
+
 exports[`Scripture returns a verse as by node 1`] = `
 Object {
   "data": Object {

--- a/packages/apollos-data-connector-bible/src/__tests__/resolver.tests.js
+++ b/packages/apollos-data-connector-bible/src/__tests__/resolver.tests.js
@@ -21,6 +21,45 @@ ApollosConfig.loadJs({
   },
 });
 
+const oneVerseMock = [
+  {
+    id: 'SNG.1.1',
+    orgId: 'SNG.1.1',
+    bibleId: '9879dbb7cfe39e4d-01',
+    bookId: 'SNG',
+    chapterIds: ['SNG.1'],
+    reference: 'Song of Solomon 1:1',
+    content:
+      '<p class="p"><span data-number="1" class="v">1</span>The Song of songs, which is Solomon’s.</p>',
+    copyright: 'PUBLIC DOMAIN',
+  },
+];
+
+const twoVerseMock = [
+  {
+    id: '1PE.1.1',
+    orgId: '1PE.1.1',
+    bibleId: '9879dbb7cfe39e4d-01',
+    bookId: '1PE',
+    chapterIds: ['1PE.1'],
+    reference: '1 Peter 1:1',
+    content:
+      '<p class="p"><span data-number="1" class="v">1</span>Peter, an apostle of Jesus Christ, to the chosen ones who are living as foreigners in the Dispersion in Pontus, Galatia, Cappadocia, Asia, and Bithynia, </p>',
+    copyright: 'PUBLIC DOMAIN',
+  },
+  {
+    id: 'JHN.3.16',
+    orgId: 'JHN.3.16',
+    bibleId: '9879dbb7cfe39e4d-01',
+    bookId: 'JHN',
+    chapterIds: ['JHN.3'],
+    reference: 'John 3:16',
+    content:
+      '<p class="p"><span data-number="16" class="v">16</span><span class="wj">For God so loved the world, that he gave his one and only Son, that whoever believes in him should not perish, but have eternal life. </span></p>',
+    copyright: 'PUBLIC DOMAIN',
+  },
+];
+
 const { getContext, getSchema } = createTestHelpers({ Scripture });
 
 describe('Scripture', () => {
@@ -51,10 +90,15 @@ describe('Scripture', () => {
         }
       }
     `;
+    context.dataSources.Scripture.get = jest.fn(() => ({
+      data: {
+        passages: oneVerseMock,
+      },
+    }));
     const rootValue = {};
-
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
+    expect(context.dataSources.Scripture.get.mock.calls[0]).toMatchSnapshot();
   });
 
   it('returns multiple verses', async () => {
@@ -69,8 +113,12 @@ describe('Scripture', () => {
         }
       }
     `;
+    context.dataSources.Scripture.get = jest.fn(() => ({
+      data: {
+        passages: twoVerseMock,
+      },
+    }));
     const rootValue = {};
-
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });
@@ -93,7 +141,6 @@ describe('Scripture', () => {
       }
     `;
     const rootValue = {};
-
     const result = await graphql(schema, query, rootValue, context);
     expect(result).toMatchSnapshot();
   });

--- a/packages/apollos-data-connector-bible/src/data-source.js
+++ b/packages/apollos-data-connector-bible/src/data-source.js
@@ -64,6 +64,7 @@ export default class Scripture extends RESTDataSource {
         version: safeVersion,
       }));
     }
+    console.warn(`No scripture returned, query: ${query} may be invalid`);
     return [];
   }
 }

--- a/packages/apollos-data-connector-bible/src/data-source.js
+++ b/packages/apollos-data-connector-bible/src/data-source.js
@@ -58,19 +58,12 @@ export default class Scripture extends RESTDataSource {
         cacheOptions: { ttl: ONE_DAY },
       }
     );
-    // Bible.api has a history of making unexpected API changes.
-    // At one point scriptures had a sub field, "passages"
-    // At another point, they returned the passage data on the `data` key directly.
-    // We should handle both for the time being.
     if (get(scriptures, 'data.passages')) {
       return scriptures.data.passages.map((passage) => ({
         ...passage,
         version: safeVersion,
       }));
     }
-    return scriptures.data.map((passage) => ({
-      ...passage,
-      version: safeVersion,
-    }));
+    return [];
   }
 }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Bible.API returns `data` with a different struture than we are expecting if the query was invalid. This just returns an empty array, signalling that something went wrong in the query.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._