### PR TITLE
feat: Adds Discover Feed Query

### DIFF
--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -1,0 +1,35 @@
+import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
+import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
+import ApollosConfig from '@apollosproject/config';
+
+const resolver = {
+  FeatureFeed: {
+    // lazy-loaded
+    features: ({ getFeatures }) => getFeatures(),
+  },
+};
+
+class FeatureFeed extends RockApolloDataSource {
+  getFromId = (id) => {
+    const {
+      id: { type, args },
+    } = parseGlobalId(id);
+    return this.getFeed({ type, args });
+  };
+
+  getFeed = ({ type = '', args = {} }) => {
+    let config = [];
+    if (type === 'apollosConfig' && args.section === 'home')
+      config = ApollosConfig.HOME_FEATURES || [];
+    else if (type === 'apollosConfig' && args.section === 'discover')
+      config = ApollosConfig.DISCOVER_FEATURES || [];
+
+    return {
+      __typename: 'FeatureFeed',
+      id: createGlobalId({ type, args }, 'FeatureFeed'),
+      getFeatures: () => this.getFeatures(config),
+    };
+  };
+}
+
+export default { resolver, dataSource: FeatureFeed };

--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -31,6 +31,8 @@ class FeatureFeed extends RockApolloDataSource {
   };
 
   getFeed = ({ type = '', args = {} }) => {
+    const { Feature } = this.context.dataSources;
+
     let config = [];
     if (type === 'apollosConfig' && args.section === 'home')
       config = ApollosConfig.HOME_FEATURES || [];
@@ -40,7 +42,7 @@ class FeatureFeed extends RockApolloDataSource {
     return {
       __typename: 'FeatureFeed',
       id: createGlobalId({ type, args }, 'FeatureFeed'),
-      getFeatures: () => this.getFeatures(config),
+      getFeatures: () => Feature.getFeatures(config),
     };
   };
 }

--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -24,10 +24,7 @@ const resolver = {
 
 class FeatureFeed extends RockApolloDataSource {
   getFromId = (id) => {
-    const {
-      id: { type, args },
-    } = parseGlobalId(id);
-    return this.getFeed({ type, args });
+    return this.getFeed(JSON.parse(id));
   };
 
   getFeed = ({ type = '', args = {} }) => {
@@ -41,10 +38,12 @@ class FeatureFeed extends RockApolloDataSource {
 
     return {
       __typename: 'FeatureFeed',
-      id: createGlobalId({ type, args }, 'FeatureFeed'),
+      id: createGlobalId(JSON.stringify({ type, args }), 'FeatureFeed'),
+      // Defer parsing of feature feed if not requested in gql.
+      // Useful if the config comes from the network.
       getFeatures: () => Feature.getFeatures(config),
     };
   };
 }
 
-export default { resolver, dataSource: FeatureFeed };
+export { resolver, FeatureFeed as dataSource };

--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -5,7 +5,10 @@ import ApollosConfig from '@apollosproject/config';
 const resolver = {
   Query: {
     homeFeedFeatures: async (root, args, { dataSources: { FeatureFeed } }) =>
-      FeatureFeed.getFeed({ type: 'apollosConfig', args: { section: 'home' } }),
+      FeatureFeed.getFeed({
+        type: 'apollosConfig',
+        args: { section: 'HOME_FEATURES' },
+      }),
     discoverFeedFeatures: async (
       root,
       args,
@@ -13,7 +16,7 @@ const resolver = {
     ) =>
       FeatureFeed.getFeed({
         type: 'apollosConfig',
-        args: { section: 'discover' },
+        args: { section: 'DISCOVER_FEED' },
       }),
   },
   FeatureFeed: {
@@ -27,21 +30,28 @@ class FeatureFeed extends RockApolloDataSource {
     return this.getFeed(JSON.parse(id));
   };
 
-  getFeed = ({ type = '', args = {} }) => {
-    const { Feature } = this.context.dataSources;
+  getApollosConfigFeatures(args) {
+    if (ApollosConfig[args.section]) {
+      return this.context.dataSources.Feature.getFeatures(
+        ApollosConfig[args.section]
+      );
+    }
+    return [];
+  }
 
-    let config = [];
-    if (type === 'apollosConfig' && args.section === 'home')
-      config = ApollosConfig.HOME_FEATURES || [];
-    else if (type === 'apollosConfig' && args.section === 'discover')
-      config = ApollosConfig.DISCOVER_FEATURES || [];
+  getFeed = ({ type = '', args = {} }) => {
+    let getFeatures;
+
+    if (type === 'apollosConfig') {
+      getFeatures = this.getApollosConfigFeatures.bind(this);
+    }
 
     return {
       __typename: 'FeatureFeed',
       id: createGlobalId(JSON.stringify({ type, args }), 'FeatureFeed'),
       // Defer parsing of feature feed if not requested in gql.
       // Useful if the config comes from the network.
-      getFeatures: () => Feature.getFeatures(config),
+      getFeatures: () => getFeatures(args),
     };
   };
 }

--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -3,6 +3,19 @@ import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
 import ApollosConfig from '@apollosproject/config';
 
 const resolver = {
+  Query: {
+    homeFeedFeatures: async (root, args, { dataSources: { FeatureFeed } }) =>
+      FeatureFeed.getFeed({ type: 'apollosConfig', args: { section: 'home' } }),
+    discoverFeedFeatures: async (
+      root,
+      args,
+      { dataSources: { FeatureFeed } }
+    ) =>
+      FeatureFeed.getFeed({
+        type: 'apollosConfig',
+        args: { section: 'discover' },
+      }),
+  },
   FeatureFeed: {
     // lazy-loaded
     features: ({ getFeatures }) => getFeatures(),

--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -1,5 +1,5 @@
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
-import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
+import { createGlobalId } from '@apollosproject/server-core';
 import ApollosConfig from '@apollosproject/config';
 
 const resolver = {

--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -16,7 +16,7 @@ const resolver = {
     ) =>
       FeatureFeed.getFeed({
         type: 'apollosConfig',
-        args: { section: 'DISCOVER_FEED' },
+        args: { section: 'DISCOVER_FEATURES' },
       }),
   },
   FeatureFeed: {

--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -452,7 +452,9 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
 
   // deprecated
   getHomeFeedFeatures = () =>
-    this.getFeatures(get(ApollosConfig, 'HOME_FEATURES', []));
+    console.warn(
+      'getHomeFeedFeatures is deprecated, please use FeatureFeed.getFeed({type: "apollosConfig", args: {"section": "home"}})'
+    ) || this.getFeatures(get(ApollosConfig, 'HOME_FEATURES', []));
 
   getFeatures = async (featuresConfig = []) => {
     return Promise.all(

--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -451,9 +451,10 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
   }
 
   // deprecated
-  getHomeFeedFeatures = this.getFeedFeatures.bind(this);
+  getHomeFeedFeatures = () =>
+    this.getFeatures(get(ApollosConfig, 'HOME_FEATURES', []));
 
-  async getFeedFeatures(featuresConfig = []) {
+  getFeatures = async (featuresConfig = []) => {
     return Promise.all(
       featuresConfig.map((featureConfig) => {
         switch (featureConfig.type) {
@@ -477,5 +478,5 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
         }
       })
     );
-  }
+  };
 }

--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -450,9 +450,12 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
       .join('\n\n');
   }
 
-  async getHomeFeedFeatures() {
+  // deprecated
+  getHomeFeedFeatures = this.getFeedFeatures.bind(this);
+
+  async getFeedFeatures(featuresConfig = []) {
     return Promise.all(
-      get(ApollosConfig, 'HOME_FEATURES', []).map((featureConfig) => {
+      featuresConfig.map((featureConfig) => {
         switch (featureConfig.type) {
           case 'VerticalCardList':
             return this.createVerticalCardListFeature(featureConfig);

--- a/packages/apollos-data-connector-rock/src/features/resolver.js
+++ b/packages/apollos-data-connector-rock/src/features/resolver.js
@@ -1,5 +1,6 @@
 import { get } from 'lodash';
 import { createGlobalId } from '@apollosproject/server-core';
+import ApollosConfig from '@apollosproject/config';
 
 export default {
   WeekendContentItem: {
@@ -47,7 +48,12 @@ export default {
   },
   Query: {
     userFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
-      Feature.getHomeFeedFeatures(),
+      console.warn('getHomeFeedFeatures is deprecated. Use getFeedFeatures.') ||
+      Feature.getHomeFeedFeatures(get(ApollosConfig, 'HOME_FEATURES', [])),
+    homeFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
+      Feature.getFeedFeatures(get(ApollosConfig, 'HOME_FEATURES', [])),
+    discoverFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
+      Feature.getFeedFeatures(get(ApollosConfig, 'DISCOVER_FEATURES', [])),
   },
   ActionListFeature: {
     id: ({ id }) => createGlobalId(id, 'ActionListFeature'),

--- a/packages/apollos-data-connector-rock/src/features/resolver.js
+++ b/packages/apollos-data-connector-rock/src/features/resolver.js
@@ -47,19 +47,8 @@ export default {
   },
   Query: {
     userFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
-      console.warn('getHomeFeedFeatures is deprecated. Use getFeedFeatures.') ||
+      console.warn('userFeedFeatures is deprecated. Use homeFeedFeatures.') ||
       Feature.getHomeFeedFeatures(),
-    homeFeedFeatures: async (root, args, { dataSources: { FeatureFeed } }) =>
-      FeatureFeed.getFeed({ type: 'apollosConfig', args: { section: 'home' } }),
-    discoverFeedFeatures: async (
-      root,
-      args,
-      { dataSources: { FeatureFeed } }
-    ) =>
-      FeatureFeed.getFeed({
-        type: 'apollosConfig',
-        args: { section: 'discover' },
-      }),
   },
   ActionListFeature: {
     id: ({ id }) => createGlobalId(id, 'ActionListFeature'),

--- a/packages/apollos-data-connector-rock/src/features/resolver.js
+++ b/packages/apollos-data-connector-rock/src/features/resolver.js
@@ -1,6 +1,5 @@
 import { get } from 'lodash';
 import { createGlobalId } from '@apollosproject/server-core';
-import ApollosConfig from '@apollosproject/config';
 
 export default {
   WeekendContentItem: {
@@ -49,11 +48,18 @@ export default {
   Query: {
     userFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
       console.warn('getHomeFeedFeatures is deprecated. Use getFeedFeatures.') ||
-      Feature.getHomeFeedFeatures(get(ApollosConfig, 'HOME_FEATURES', [])),
-    homeFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
-      Feature.getFeedFeatures(get(ApollosConfig, 'HOME_FEATURES', [])),
-    discoverFeedFeatures: async (root, args, { dataSources: { Feature } }) =>
-      Feature.getFeedFeatures(get(ApollosConfig, 'DISCOVER_FEATURES', [])),
+      Feature.getHomeFeedFeatures(),
+    homeFeedFeatures: async (root, args, { dataSources: { FeatureFeed } }) =>
+      FeatureFeed.getFeed({ type: 'apollosConfig', args: { section: 'home' } }),
+    discoverFeedFeatures: async (
+      root,
+      args,
+      { dataSources: { FeatureFeed } }
+    ) =>
+      FeatureFeed.getFeed({
+        type: 'apollosConfig',
+        args: { section: 'discover' },
+      }),
   },
   ActionListFeature: {
     id: ({ id }) => createGlobalId(id, 'ActionListFeature'),

--- a/packages/apollos-data-connector-rock/src/index.js
+++ b/packages/apollos-data-connector-rock/src/index.js
@@ -14,6 +14,7 @@ import * as Group from './groups';
 import * as Utils from './utils';
 import * as BinaryFiles from './binary-files';
 import * as Feature from './features';
+import * as FeatureFeed from './feature-feeds';
 import * as Event from './events';
 import * as PrayerRequest from './prayer-request';
 
@@ -34,6 +35,7 @@ export {
   Utils,
   BinaryFiles,
   Feature,
+  FeatureFeed,
   Event,
   PrayerRequest,
 };

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -930,8 +930,8 @@ export const featuresSchema = gql`
     userFeedFeatures: [Feature]
       @cacheControl(maxAge: 0)
       @deprecated(reason: "Use homeFeedFeatures or discoverFeedFeatures")
-    homeFeedFeatures: [Feature] @cacheControl(maxAge: 0)
-    discoverFeedFeatures: [Feature] @cacheControl(maxAge: 0)
+    homeFeedFeatures: FeatureFeed @cacheControl(maxAge: 0)
+    discoverFeedFeatures: FeatureFeed @cacheControl(maxAge: 0)
   }
 `;
 


### PR DESCRIPTION
This PR breaks out the `userFeedFeatures` query into `homeFeedFeatures` and `discoverFeedFeatures` and defines a new way to deterministically generate a feed of feeds. Look through the schema for details. Test with `feature-feed` branch in templates.

<img width="1539" alt="Screen Shot 2020-10-13 at 1 19 38 PM" src="https://user-images.githubusercontent.com/2659478/95894204-c0ec6b00-0d56-11eb-8056-e916553d5a8f.png">
