### PR TITLE
chore: Old fashioned beta releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "TZ=utc lerna run test",
     "ci-test": "lerna run test  --stream -- --maxWorkers=2",
     "release": "lerna publish --conventional-commits --force-publish",
-    "release:beta": "lerna publish --conventional-commits --canary --preid beta --dist-tag beta --force-publish",
+    "release:beta": "lerna publish --conventional-commits --conventional-prerelease --preid beta --dist-tag beta --force-publish",
     "release:canary": "lerna publish --conventional-commits --canary --yes",
     "prepublishOnly": "lerna run build && lerna run generate-stories",
     "nuke": "./scripts/boom.sh && yarn nuke:node && yarn nuke:cache",


### PR DESCRIPTION
We can't do them the other way because canaries only the minor version regardless of conventional tags so we'd never get a 1.7.0-beta
