### PR TITLE
fix: Fixes Actions with Defined related node

### DIFF
--- a/packages/apollos-data-connector-rock/src/features/data-source.js
+++ b/packages/apollos-data-connector-rock/src/features/data-source.js
@@ -27,6 +27,8 @@ export default class Feature extends RockApolloDataSource {
 
   // eslint-disable-next-line class-methods-use-this
   attachRelatedNodeId({ relatedNode, ...action } = {}) {
+    // if we already have an ID, return as is
+    if (relatedNode?.id) return { relatedNode, ...action };
     if (relatedNode && !relatedNode.id) {
       return {
         ...action,


### PR DESCRIPTION
If a related node was defined already, the function was stripping it off. this fixes that
