### PR TITLE
fix: Use redis cache for rock-constants code

### DIFF
--- a/packages/apollos-data-connector-rock/src/rock-constants/__tests__/__snapshots__/rock-constants.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/rock-constants/__tests__/__snapshots__/rock-constants.tests.js.snap
@@ -19,11 +19,7 @@ Array [
   Array [
     "InteractionChannels?%24filter=%28Name%20eq%20%27Apollos%20App%20-%20Content%20Channel%20Item%27%29%20and%20%28UsesSession%20eq%20false%29%20and%20%28IsActive%20eq%20true%29%20and%20%28ComponentEntityTypeId%20eq%20101%29%20and%20%28ChannelTypeMediumValueId%20eq%20512%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
   Array [
     "/InteractionChannels/1",
@@ -61,11 +57,7 @@ Array [
   Array [
     "InteractionChannels?%24filter=%28Name%20eq%20%27Apollos%20App%20-%20Content%20Channel%20Item%27%29%20and%20%28UsesSession%20eq%20false%29%20and%20%28IsActive%20eq%20true%29%20and%20%28ComponentEntityTypeId%20eq%20101%29%20and%20%28ChannelTypeMediumValueId%20eq%20512%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
   Array [
     "/InteractionChannels/1",
@@ -73,11 +65,7 @@ Array [
   Array [
     "InteractionComponents?%24filter=%28Name%20eq%20%27Apollos%20Content%20Item%20-%207%27%29%20and%20%28ChannelId%20eq%201%29%20and%20%28EntityId%20eq%207%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
 ]
 `;
@@ -92,6 +80,54 @@ Array [
       "IsActive": true,
       "Name": "Apollos App - Content Channel Item",
       "UsesSession": false,
+    },
+  ],
+]
+`;
+
+exports[`RockConstants creates a content item Component if it doesn't exist: cache get 1`] = `
+Array [
+  Array [
+    Object {
+      "key": Array [
+        "rockConstants",
+        "InteractionChannels",
+        "{\\"Name\\":\\"Apollos App - Content Channel Item\\",\\"UsesSession\\":false,\\"IsActive\\":true,\\"ComponentEntityTypeId\\":101,\\"ChannelTypeMediumValueId\\":512}",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "key": Array [
+        "rockConstants",
+        "InteractionComponents",
+        "{\\"Name\\":\\"Apollos Content Item - 7\\",\\"ChannelId\\":1,\\"EntityId\\":7}",
+      ],
+    },
+  ],
+]
+`;
+
+exports[`RockConstants creates a content item Component if it doesn't exist: cache set 1`] = `
+Array [
+  Array [
+    Object {
+      "data": "{\\"id\\":1}",
+      "key": Array [
+        "rockConstants",
+        "InteractionChannels",
+        "{\\"Name\\":\\"Apollos App - Content Channel Item\\",\\"UsesSession\\":false,\\"IsActive\\":true,\\"ComponentEntityTypeId\\":101,\\"ChannelTypeMediumValueId\\":512}",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "data": "[]",
+      "key": Array [
+        "rockConstants",
+        "InteractionComponents",
+        "{\\"Name\\":\\"Apollos Content Item - 7\\",\\"ChannelId\\":1,\\"EntityId\\":7}",
+      ],
     },
   ],
 ]
@@ -112,11 +148,7 @@ Array [
   Array [
     "InteractionChannels?%24filter=%28Name%20eq%20%27Apollos%20App%20-%20Content%20Channel%20Item%27%29%20and%20%28UsesSession%20eq%20false%29%20and%20%28IsActive%20eq%20true%29%20and%20%28ComponentEntityTypeId%20eq%20101%29%20and%20%28ChannelTypeMediumValueId%20eq%20512%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
   Array [
     "/InteractionChannels/1",
@@ -124,11 +156,7 @@ Array [
   Array [
     "InteractionComponents?%24filter=%28Name%20eq%20%27Apollos%20Content%20Item%20-%207%27%29%20and%20%28InteractionChannelId%20eq%201%29%20and%20%28EntityId%20eq%207%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
 ]
 `;
@@ -239,11 +267,7 @@ Array [
   Array [
     "InteractionChannels?%24filter=%28Name%20eq%20%27Apollos%20App%20-%20Content%20Channel%20Item%27%29%20and%20%28UsesSession%20eq%20false%29%20and%20%28IsActive%20eq%20true%29%20and%20%28ComponentEntityTypeId%20eq%20101%29%20and%20%28ChannelTypeMediumValueId%20eq%20512%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
 ]
 `;
@@ -259,20 +283,93 @@ Array [
   Array [
     "InteractionChannels?%24filter=%28Name%20eq%20%27Apollos%20App%20-%20Content%20Channel%20Item%27%29%20and%20%28UsesSession%20eq%20false%29%20and%20%28IsActive%20eq%20true%29%20and%20%28ComponentEntityTypeId%20eq%20101%29%20and%20%28ChannelTypeMediumValueId%20eq%20512%29&%24top=1",
     Object {},
-    Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
-    },
+    Object {},
   ],
   Array [
     "InteractionComponents?%24filter=%28Name%20eq%20%27Apollos%20Content%20Item%20-%207%27%29%20and%20%28ChannelId%20eq%201%29%20and%20%28EntityId%20eq%207%29&%24top=1",
     Object {},
+    Object {},
+  ],
+]
+`;
+
+exports[`RockConstants finds the content item Component if it exists: cache get 1`] = `
+Array [
+  Array [
     Object {
-      "cacheOptions": Object {
-        "ttl": 86400,
-      },
+      "key": Array [
+        "rockConstants",
+        "InteractionChannels",
+        "{\\"Name\\":\\"Apollos App - Content Channel Item\\",\\"UsesSession\\":false,\\"IsActive\\":true,\\"ComponentEntityTypeId\\":101,\\"ChannelTypeMediumValueId\\":512}",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "key": Array [
+        "rockConstants",
+        "InteractionComponents",
+        "{\\"Name\\":\\"Apollos Content Item - 7\\",\\"ChannelId\\":1,\\"EntityId\\":7}",
+      ],
     },
   ],
 ]
 `;
+
+exports[`RockConstants finds the content item Component if it exists: cache set 1`] = `
+Array [
+  Array [
+    Object {
+      "data": "{\\"id\\":1}",
+      "key": Array [
+        "rockConstants",
+        "InteractionChannels",
+        "{\\"Name\\":\\"Apollos App - Content Channel Item\\",\\"UsesSession\\":false,\\"IsActive\\":true,\\"ComponentEntityTypeId\\":101,\\"ChannelTypeMediumValueId\\":512}",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "data": "{\\"id\\":1}",
+      "key": Array [
+        "rockConstants",
+        "InteractionComponents",
+        "{\\"Name\\":\\"Apollos Content Item - 7\\",\\"ChannelId\\":1,\\"EntityId\\":7}",
+      ],
+    },
+  ],
+]
+`;
+
+exports[`RockConstants pulls the item component from the cache, when it exists 1`] = `
+Object {
+  "id": "123",
+}
+`;
+
+exports[`RockConstants pulls the item component from the cache, when it exists 2`] = `Array []`;
+
+exports[`RockConstants pulls the item component from the cache, when it exists: cache get 1`] = `
+Array [
+  Array [
+    Object {
+      "key": Array [
+        "rockConstants",
+        "InteractionChannels",
+        "{\\"Name\\":\\"Apollos App - Content Channel Item\\",\\"UsesSession\\":false,\\"IsActive\\":true,\\"ComponentEntityTypeId\\":101,\\"ChannelTypeMediumValueId\\":512}",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "key": Array [
+        "rockConstants",
+        "InteractionComponents",
+        "{\\"Name\\":\\"Apollos Content Item - 7\\",\\"ChannelId\\":\\"123\\",\\"EntityId\\":7}",
+      ],
+    },
+  ],
+]
+`;
+
+exports[`RockConstants pulls the item component from the cache, when it exists: cache set 1`] = `Array []`;

--- a/packages/apollos-data-connector-rock/src/rock-constants/__tests__/rock-constants.tests.js
+++ b/packages/apollos-data-connector-rock/src/rock-constants/__tests__/rock-constants.tests.js
@@ -16,12 +16,16 @@ ApollosConfig.loadJs({
   },
 });
 
+let context;
+
 describe('RockConstants', () => {
   beforeEach(() => {
     fetch.resetMocks();
+    context = { dataSources: { Cache: { get: jest.fn(), set: jest.fn() } } };
   });
   it("creates a content item Channel if it doesn't exist", async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.modelType = buildGetMock({ id: 101 }, dataSource);
     dataSource.get = buildGetMock([[], { Id: 1 }], dataSource);
     dataSource.post = buildGetMock('1', dataSource);
@@ -42,6 +46,7 @@ describe('RockConstants', () => {
       },
     });
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.modelType = buildGetMock(
       { id: 101, friendlyName: 'Content Channel Item' },
       dataSource
@@ -64,6 +69,7 @@ describe('RockConstants', () => {
   });
   it('finds the content item Channel if it exists', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     dataSource.post = jest.fn();
     dataSource.modelType = buildGetMock(
@@ -77,6 +83,7 @@ describe('RockConstants', () => {
   });
   it("creates a content item Component if it doesn't exist", async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.modelType = buildGetMock(
       { id: 101, friendlyName: 'Content Channel Item' },
       dataSource
@@ -91,9 +98,16 @@ describe('RockConstants', () => {
     expect(dataSource.modelType.mock.calls).toMatchSnapshot();
     expect(dataSource.get.mock.calls).toMatchSnapshot();
     expect(dataSource.post.mock.calls).toMatchSnapshot();
+    expect(context.dataSources.Cache.get.mock.calls).toMatchSnapshot(
+      'cache get'
+    );
+    expect(context.dataSources.Cache.set.mock.calls).toMatchSnapshot(
+      'cache set'
+    );
   });
   it('finds the content item Component if it exists', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     dataSource.post = jest.fn();
     dataSource.modelType = buildGetMock(
@@ -107,9 +121,42 @@ describe('RockConstants', () => {
     expect(result).toMatchSnapshot();
     expect(dataSource.get.mock.calls).toMatchSnapshot();
     expect(dataSource.post.mock.calls.length).toBe(0);
+    expect(context.dataSources.Cache.get.mock.calls).toMatchSnapshot(
+      'cache get'
+    );
+    expect(context.dataSources.Cache.set.mock.calls).toMatchSnapshot(
+      'cache set'
+    );
+  });
+  it('pulls the item component from the cache, when it exists', async () => {
+    const dataSource = new RockConstants();
+    dataSource.context = context;
+    context.dataSources.Cache.get = jest.fn(() =>
+      JSON.stringify({ id: '123' })
+    );
+    dataSource.get = jest.fn();
+    dataSource.post = jest.fn();
+    dataSource.modelType = buildGetMock(
+      { id: 101, friendlyName: 'Content Channel Item' },
+      dataSource
+    );
+    const result = await dataSource.contentItemInteractionComponent({
+      contentItemId: 7,
+      contentTitle: 'Some Title',
+    });
+    expect(result).toMatchSnapshot();
+    expect(dataSource.get.mock.calls).toMatchSnapshot();
+    expect(dataSource.post.mock.calls.length).toBe(0);
+    expect(context.dataSources.Cache.get.mock.calls).toMatchSnapshot(
+      'cache get'
+    );
+    expect(context.dataSources.Cache.set.mock.calls).toMatchSnapshot(
+      'cache set'
+    );
   });
   it('finds a ContentItem model ID', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     const result = await dataSource.modelType('ContentItem');
     expect(result).toMatchSnapshot();
@@ -117,6 +164,7 @@ describe('RockConstants', () => {
   });
   it('finds a custom entity model ID', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     const result = await dataSource.modelType('ApollosGroup');
     expect(result).toMatchSnapshot();
@@ -124,6 +172,7 @@ describe('RockConstants', () => {
   });
   it('finds a model ID for an item not using ContentChannelItem', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     const result = await dataSource.modelType('DevotionalContentItem');
     expect(result).toMatchSnapshot();
@@ -131,6 +180,7 @@ describe('RockConstants', () => {
   });
   it('finds a UniversalContentItem model ID', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     const result = await dataSource.modelType('UniversalContentItem');
     expect(result).toMatchSnapshot();
@@ -138,6 +188,7 @@ describe('RockConstants', () => {
   });
   it('Throws when finding an unknown model ', () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([{ Id: 1 }], dataSource);
     const prom = dataSource.modelType('IDontExist');
     expect(prom).rejects.toEqual(
@@ -146,6 +197,7 @@ describe('RockConstants', () => {
   });
   it('Returns null if model type not found ', async () => {
     const dataSource = new RockConstants();
+    dataSource.context = context;
     dataSource.get = buildGetMock([], dataSource);
     const result = await dataSource.modelType('ContentItem');
     expect(result).toEqual(null);

--- a/packages/apollos-data-connector-rock/src/rock-constants/index.js
+++ b/packages/apollos-data-connector-rock/src/rock-constants/index.js
@@ -7,6 +7,17 @@ const { ROCK_MAPPINGS } = ApollosConfig;
 class RockConstants extends RockApolloDataSource {
   async findOrCreate({ model, objectAttributes }) {
     // Turns {ChannelId: 7, Name: 'Something'} into '(ChannelId eq 7) and (Name eq 'Something')'
+    const { Cache } = this.context.dataSources;
+
+    const cacheKey = ['rockConstants', model, JSON.stringify(objectAttributes)];
+    const cachedObj = await Cache.get({ key: cacheKey });
+
+    // If we have a cached object, return it.
+    if (cachedObj) {
+      return JSON.parse(cachedObj);
+    }
+
+    // If we don't have a cached object create a filter out of the attributes of the expected objects.
     const filter = Object.keys(objectAttributes)
       .map((key) => {
         if (typeof objectAttributes[key] === 'string') {
@@ -16,17 +27,27 @@ class RockConstants extends RockApolloDataSource {
       })
       .join(' and ');
 
+    // Look for objects matching that filter.
     const object = await this.request(model)
       .filter(filter)
-      .cache({ ttl: 86400 })
       .first();
 
+    // if we have one
     if (object) {
+      // cache it
+      await Cache.set({ key: cacheKey, data: JSON.stringify(object) });
+      // and return it.
       return object;
     }
-    const objectId = await this.post(`/${model}`, objectAttributes);
-    const ret = await this.get(`/${model}/${objectId}`);
 
+    // Otherwise, if no object matching the `objectAttributes` exists, create it.
+    const objectId = await this.post(`/${model}`, objectAttributes);
+    // Go grab the newly created object
+    const ret = await this.get(`/${model}/${objectId}`);
+    // Cache it
+    await Cache.set({ key: cacheKey, data: JSON.stringify(ret) });
+
+    // And return it.
     return ret;
   }
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Brian at Newspring found a bug that goes something like this: 

A new piece of content is published 

A user interacts with that content, we check to see if there's a component for it, see that there's not, and **cache the result of that call for 24 hours**
We then create a component for that content item. 

Another user interacts with that content, the cached result for the component is returned, and we create **another** new component. 

This continues for 24 hours passes and the cache clears (or until the server restarts). 
The fix that I've implemented is to ditch the apollo-datasource-cache and use the Redis cache, which gives me the control to ensure that we only cache created components, and never cache an empty state. 

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
