### PR TITLE
fix: Stop ThemeMixin from clobbering ThemeInput

### DIFF
--- a/ApollosStorybook/yarn.lock
+++ b/ApollosStorybook/yarn.lock
@@ -54,10 +54,10 @@
   version "0.0.0"
   uid ""
 
-"@apollosproject/ui-kit@^1.7.0-beta.2":
-  version "1.7.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.7.0-beta.2.tgz#71e3e9e792d5388489df4016176605ebfb61efe6"
-  integrity sha512-vQ3VgTnS5zn2C99G4hjjE7WDXKRg2Kujpeiusk6qN4LdBLvsKF3ifkcyRzcF46k0CuhhwwSxz6/sxKk8kJv62g==
+"@apollosproject/ui-kit@^1.7.0-beta.3":
+  version "1.7.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.7.0-beta.3.tgz#202a7f1a105f32d0bca4958550a1f31b8e0c8747"
+  integrity sha512-pIwdbl2G55iI57jfgMqn6A7ckMJJqzvzkDk7q1pcCMoxHdDOS+GmUVLViHXuJPWFgKeQPIG02H6A77f+DaTBbg==
   dependencies:
     "@react-native-community/blur" "^3.6.0"
     color "^3.1.0"
@@ -101,10 +101,10 @@
   version "0.0.0"
   uid ""
 
-"@apollosproject/ui-storybook@^1.7.0-beta.2":
-  version "1.7.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-storybook/-/ui-storybook-1.7.0-beta.2.tgz#838886eaf2d0038ba2b8cf13cffef9ce07e598f5"
-  integrity sha512-W34ys9ufI6rEtxyQftznSDMT0cBaCEaqRgDq9dXxJkthKIy+S8woAJ4TeVvhz/EtlA3sjXjb5n8I8vzvtV4alw==
+"@apollosproject/ui-storybook@^1.7.0-beta.3":
+  version "1.7.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-storybook/-/ui-storybook-1.7.0-beta.3.tgz#6b49d241d5ba0373f66bb726f56e9c52114a7a88"
+  integrity sha512-g91lbwUrQDhpkhRkMKvjq4/E8k3GLa7Oxs6FzxrpXdIxR89RP+SxCGIKAB44mo+zSxN+0IE0bZf8FKiRhdSmiw==
   dependencies:
     "@storybook/addon-actions" "5.2.4"
     "@storybook/addon-links" "5.2.4"

--- a/packages/apollos-ui-kit/src/theme/__snapshots__/mixins.tests.js.snap
+++ b/packages/apollos-ui-kit/src/theme/__snapshots__/mixins.tests.js.snap
@@ -18,7 +18,7 @@ exports[`withThemeMixin overrides styles without affecting siblings 1`] = `
     <Text
       style={
         Object {
-          "color": "#303030",
+          "color": "#00676D",
           "fontFamily": "InterUI-Black",
           "fontSize": 24,
           "lineHeight": 27.6,
@@ -30,7 +30,7 @@ exports[`withThemeMixin overrides styles without affecting siblings 1`] = `
     <Text
       style={
         Object {
-          "color": "#505050",
+          "color": "#17B582",
           "fontFamily": "InterUI-Bold",
           "fontSize": 12,
           "lineHeight": 18,
@@ -64,7 +64,7 @@ exports[`withThemeMixin overrides styles without affecting siblings 1`] = `
     <Text
       style={
         Object {
-          "color": "#F8F7F4",
+          "color": "#00676D",
           "fontFamily": "InterUI-Black",
           "fontSize": 24,
           "lineHeight": 27.6,
@@ -76,7 +76,7 @@ exports[`withThemeMixin overrides styles without affecting siblings 1`] = `
     <Text
       style={
         Object {
-          "color": "#DBDBD9",
+          "color": "#17B582",
           "fontFamily": "InterUI-Bold",
           "fontSize": 12,
           "lineHeight": 18,
@@ -110,7 +110,7 @@ exports[`withThemeMixin overrides styles without affecting siblings 1`] = `
     <Text
       style={
         Object {
-          "color": "#303030",
+          "color": "#00676D",
           "fontFamily": "InterUI-Black",
           "fontSize": 24,
           "lineHeight": 27.6,
@@ -122,7 +122,7 @@ exports[`withThemeMixin overrides styles without affecting siblings 1`] = `
     <Text
       style={
         Object {
-          "color": "#505050",
+          "color": "#17B582",
           "fontFamily": "InterUI-Bold",
           "fontSize": 12,
           "lineHeight": 18,
@@ -167,7 +167,7 @@ exports[`withThemeMixin prunes null inputs 1`] = `
     <Text
       style={
         Object {
-          "color": "#303030",
+          "color": "#00676D",
           "fontFamily": "InterUI-Black",
           "fontSize": 24,
           "lineHeight": 27.6,
@@ -179,7 +179,64 @@ exports[`withThemeMixin prunes null inputs 1`] = `
     <Text
       style={
         Object {
-          "color": "#505050",
+          "color": "#17B582",
+          "fontFamily": "InterUI-Bold",
+          "fontSize": 12,
+          "lineHeight": 18,
+        }
+      }
+    >
+      Lorem ipsum dolor sit amet.
+    </Text>
+    <Text
+      bold={false}
+      italic={false}
+      style={
+        Object {
+          "color": "#303030",
+          "fontFamily": "InterUI-Regular",
+          "fontSize": 16,
+          "lineHeight": 26,
+        }
+      }
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales sit amet ante eu lobortis. In vitae faucibus lectus, at interdum nibh. Fusce suscipit tincidunt justo, vitae cursus mi fermentum eget.
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`withThemeMixin reverts to themeInput when mixin has null values 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "salmon",
+          "fontFamily": "InterUI-Black",
+          "fontSize": 24,
+          "lineHeight": 27.6,
+        }
+      }
+    >
+      Hi there!
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "blue",
           "fontFamily": "InterUI-Bold",
           "fontSize": 12,
           "lineHeight": 18,
@@ -224,7 +281,7 @@ exports[`withThemeMixin works with dynamic props 1`] = `
     <Text
       style={
         Object {
-          "color": "#303030",
+          "color": "red",
           "fontFamily": "InterUI-Black",
           "fontSize": 24,
           "lineHeight": 27.6,
@@ -236,7 +293,7 @@ exports[`withThemeMixin works with dynamic props 1`] = `
     <Text
       style={
         Object {
-          "color": "#505050",
+          "color": "#17B582",
           "fontFamily": "InterUI-Bold",
           "fontSize": 12,
           "lineHeight": 18,
@@ -270,7 +327,7 @@ exports[`withThemeMixin works with dynamic props 1`] = `
     <Text
       style={
         Object {
-          "color": "#F8F7F4",
+          "color": "blue",
           "fontFamily": "InterUI-Black",
           "fontSize": 24,
           "lineHeight": 27.6,
@@ -282,7 +339,7 @@ exports[`withThemeMixin works with dynamic props 1`] = `
     <Text
       style={
         Object {
-          "color": "#DBDBD9",
+          "color": "#17B582",
           "fontFamily": "InterUI-Bold",
           "fontSize": 12,
           "lineHeight": 18,

--- a/packages/apollos-ui-kit/src/theme/mixin.stories.js
+++ b/packages/apollos-ui-kit/src/theme/mixin.stories.js
@@ -1,0 +1,91 @@
+/* eslint-disable */
+import React from 'react';
+import { storiesOf } from '@apollosproject/ui-storybook';
+
+import FlexedView from '../FlexedView';
+import { H3, H6, BodyText } from '../typography';
+
+import { ThemeProvider, ThemeMixin, withThemeMixin } from './';
+import styled from '../styled'
+import CenteredView from '../CenteredView'
+
+const MixinPrimaryText = styled(({ theme: { colors: { primary } } }) => ({ color: primary }))(H3);
+const MixinSecondaryText = styled(({ theme: { colors: { secondary } } }) => ({ color: secondary }))(H3);
+const MixinTertiaryText = styled(({ theme: { colors: { tertiary } } }) => ({ color: tertiary }))(H3);
+
+
+const newTheme = {
+  colors: {
+    primary: 'red',
+    secondary: 'blue',
+  }
+}
+
+storiesOf('ui-kit/mixin', module)
+  .add('Mixins - default', () => (
+    <ThemeProvider themeInput={newTheme}>
+      <CenteredView>
+        <MixinPrimaryText>
+          I am primary! That means I'm red.
+        </MixinPrimaryText>
+        <MixinSecondaryText>
+          I am secondary! That means I'm blue.
+        </MixinSecondaryText>
+        <MixinTertiaryText>
+          I am tertiary! That means I'm inheriting my value from the core theme.
+        </MixinTertiaryText>
+      </CenteredView>
+    </ThemeProvider>
+  ))
+  .add('Mixins - all three colors', () => (
+    <ThemeProvider themeInput={newTheme}>
+      <CenteredView>
+        <ThemeMixin mixin={{ colors: { primary: 'salmon', secondary: 'yellow', tertiary: 'purple' } }}>
+          <MixinPrimaryText>
+            I am primary! That means I'm salmon.
+          </MixinPrimaryText>
+          <MixinSecondaryText>
+            I am secondary! That means I'm yellow.
+          </MixinSecondaryText>
+          <MixinTertiaryText>
+            I am tertiary! That means I'm purple.
+          </MixinTertiaryText>
+        </ThemeMixin>
+      </CenteredView>
+    </ThemeProvider>
+  ))
+  .add('Mixins - secondary null', () => (
+    <ThemeProvider themeInput={newTheme}>
+      <CenteredView>
+        <ThemeMixin mixin={{ colors: { primary: 'salmon', secondary: null, tertiary: 'purple' } }}>
+          <MixinPrimaryText>
+            I am primary! That means I'm salmon.
+          </MixinPrimaryText>
+          <MixinSecondaryText>
+            I am secondary! That means I'm blue (from theme input).
+          </MixinSecondaryText>
+          <MixinTertiaryText>
+            I am tertiary! That means I'm purple.
+          </MixinTertiaryText>
+        </ThemeMixin>
+      </CenteredView>
+    </ThemeProvider>
+  ))
+  .add('Mixins - tertiary null', () => (
+    <ThemeProvider themeInput={newTheme}>
+      <CenteredView>
+        <ThemeMixin mixin={{ colors: { primary: 'salmon', secondary: 'yellow', tertiary: null } }}>
+          <MixinPrimaryText>
+            I am primary! That means I'm salmon.
+          </MixinPrimaryText>
+          <MixinSecondaryText>
+            I am secondary! That means I'm yellow.
+          </MixinSecondaryText>
+          <MixinTertiaryText>
+            I am tertiary! That means I'm inheriting my value from the core theme.
+          </MixinTertiaryText>
+        </ThemeMixin>
+      </CenteredView>
+    </ThemeProvider>
+  ));
+

--- a/packages/apollos-ui-kit/src/theme/mixins.js
+++ b/packages/apollos-ui-kit/src/theme/mixins.js
@@ -52,8 +52,10 @@ const withThemeMixin = (themeInput) =>
         // This is important. Null leaves will override default values from the base theme, without providing a replacement.
         // This causes the app to crash if you're not careful to provide values for the entire theme.
         // Very common when sending GQL data over the wire.
-        themeInputAsObject = stripNullLeaves(
-          merge({}, originalThemeInput, themeInputAsObject)
+        themeInputAsObject = merge(
+          {},
+          originalThemeInput,
+          stripNullLeaves(themeInputAsObject)
         );
 
         const themeWithMixin = createTheme(themeInputAsObject);

--- a/packages/apollos-ui-kit/src/theme/mixins.tests.js
+++ b/packages/apollos-ui-kit/src/theme/mixins.tests.js
@@ -7,11 +7,15 @@ import { H3, H6, BodyText } from '../typography';
 
 import { ThemeProvider } from './';
 import { withThemeMixin } from './mixins';
+import styled from '../styled';
+
+const StyledH3 = styled(({ theme: { colors: { primary }}}) => ({ color: primary }))(H3);
+const StyledH6 = styled(({ theme: { colors: { secondary }}}) => ({ color: secondary }))(H6);
 
 const TypeExample = () => (
   <FlexedView>
-    <H3>Hi there!</H3>
-    <H6>Lorem ipsum dolor sit amet.</H6>
+    <StyledH3>Hi there!</StyledH3>
+    <StyledH6>Lorem ipsum dolor sit amet.</StyledH6>
     <BodyText>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales
       sit amet ante eu lobortis. In vitae faucibus lectus, at interdum nibh.
@@ -28,6 +32,13 @@ const TypeExampleWithNullInputs = withThemeMixin({
   type: 'light',
   colors: {
     primary: null,
+    secondary: null,
+  },
+})(TypeExample);
+
+const TypeExampleWithSomeColors = withThemeMixin({
+  colors: {
+    primary: 'salmon',
     secondary: null,
   },
 })(TypeExample);
@@ -68,6 +79,16 @@ describe('withThemeMixin', () => {
       <ThemeProvider>
         <FlexedView>
           <TypeExampleWithNullInputs />
+        </FlexedView>
+      </ThemeProvider>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('reverts to themeInput when mixin has null values', () => {
+    const tree = renderer.create(
+      <ThemeProvider themeInput={{ colors: { primary: 'red', secondary: 'blue' }}}>
+        <FlexedView>
+          <TypeExampleWithSomeColors />
         </FlexedView>
       </ThemeProvider>
     );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

When using `ThemeMixin`, if you passed colors with null values, the ThemeMixin would pass down default colors **from core theme** instead of passing down colors **from the the user theme input**. 

We got around this a bunch of ways in the past, @conrad-vanl had a good fix that serviced a lot of our client apps, but I wanted to bring this fix into core and fix that "gotcha". 

<img width="570" alt="image" src="https://user-images.githubusercontent.com/1637694/98694631-af8b8400-233f-11eb-987c-d3a287480cb2.png">

Best way to test is run through the `mixin` stories I made. The colors you see should match the colors described in the text. 


### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
