### PR TITLE
feat: Make feed limit pull from config

### DIFF
--- a/ApollosStorybook/yarn.lock
+++ b/ApollosStorybook/yarn.lock
@@ -54,10 +54,10 @@
   version "0.0.0"
   uid ""
 
-"@apollosproject/ui-kit@^1.7.0-beta.2":
-  version "1.7.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.7.0-beta.2.tgz#71e3e9e792d5388489df4016176605ebfb61efe6"
-  integrity sha512-vQ3VgTnS5zn2C99G4hjjE7WDXKRg2Kujpeiusk6qN4LdBLvsKF3ifkcyRzcF46k0CuhhwwSxz6/sxKk8kJv62g==
+"@apollosproject/ui-kit@^1.7.0-beta.3":
+  version "1.7.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.7.0-beta.3.tgz#202a7f1a105f32d0bca4958550a1f31b8e0c8747"
+  integrity sha512-pIwdbl2G55iI57jfgMqn6A7ckMJJqzvzkDk7q1pcCMoxHdDOS+GmUVLViHXuJPWFgKeQPIG02H6A77f+DaTBbg==
   dependencies:
     "@react-native-community/blur" "^3.6.0"
     color "^3.1.0"
@@ -101,10 +101,10 @@
   version "0.0.0"
   uid ""
 
-"@apollosproject/ui-storybook@^1.7.0-beta.2":
-  version "1.7.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-storybook/-/ui-storybook-1.7.0-beta.2.tgz#838886eaf2d0038ba2b8cf13cffef9ce07e598f5"
-  integrity sha512-W34ys9ufI6rEtxyQftznSDMT0cBaCEaqRgDq9dXxJkthKIy+S8woAJ4TeVvhz/EtlA3sjXjb5n8I8vzvtV4alw==
+"@apollosproject/ui-storybook@^1.7.0-beta.3":
+  version "1.7.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-storybook/-/ui-storybook-1.7.0-beta.3.tgz#6b49d241d5ba0373f66bb726f56e9c52114a7a88"
+  integrity sha512-g91lbwUrQDhpkhRkMKvjq4/E8k3GLa7Oxs6FzxrpXdIxR89RP+SxCGIKAB44mo+zSxN+0IE0bZf8FKiRhdSmiw==
   dependencies:
     "@storybook/addon-actions" "5.2.4"
     "@storybook/addon-links" "5.2.4"

--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -199,7 +199,7 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }));
   }
 
-  async userFeedAlgorithm({ limit = 20 } = {}) {
+  async userFeedAlgorithm({ limit = ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT ? ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT : 20} = {}) {
     const { ContentItem } = this.context.dataSources;
 
     const items = await ContentItem.byUserFeed()

--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -199,7 +199,11 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }));
   }
 
-  async userFeedAlgorithm({ limit = ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT ? ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT : 20} = {}) {
+  async userFeedAlgorithm({
+    limit = ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT
+      ? ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT
+      : 20,
+  } = {}) {
     const { ContentItem } = this.context.dataSources;
 
     const items = await ContentItem.byUserFeed()

--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -199,11 +199,7 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }));
   }
 
-  async userFeedAlgorithm({
-    limit = ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT
-      ? ApollosConfig.ROCK_MAPPINGS.FEED_CONTENT_LIMIT
-      : 20,
-  } = {}) {
+  async userFeedAlgorithm({ limit = 20 } = {}) {
     const { ContentItem } = this.context.dataSources;
 
     const items = await ContentItem.byUserFeed()


### PR DESCRIPTION
## DESCRIPTION
This PR allows developer/church to limit the userFeed in the server config in the templates repo. It also sets it up so that if the config value is not present it will default to 20 (what was hardcoded)
### What does this PR do, or why is it needed?
For us 20 items was too many. I did not want to override the function just to limit the number of items. 
### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
