### PR TITLE
feat: Adds Whitelist to Series Progress Algorithm

### DIFF
--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -219,11 +219,13 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }));
   }
 
-  async seriesInProgressAlgorithm({ limit = 3 } = {}) {
+  async seriesInProgressAlgorithm({ limit = 3, channelIds } = {}) {
     const { ContentItem, Feature } = this.context.dataSources;
     Feature.setCacheHint({ maxAge: 0, scope: 'PRIVATE' });
 
-    const items = await (await ContentItem.getSeriesWithUserProgress())
+    const items = await (await ContentItem.getSeriesWithUserProgress({
+      channelIds,
+    }))
       .expand('ContentChannel')
       .top(limit)
       .get();

--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -219,7 +219,7 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }));
   }
 
-  async seriesInProgressAlgorithm({ limit = 3, channelIds } = {}) {
+  async seriesInProgressAlgorithm({ limit = 3, channelIds = [] } = {}) {
     const { ContentItem, Feature } = this.context.dataSources;
     Feature.setCacheHint({ maxAge: 0, scope: 'PRIVATE' });
 

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -560,6 +560,36 @@ Array [
 ]
 `;
 
+exports[`ContentItemsModel gets series from specific channel a user has viewed: get from ids 1`] = `
+Array [
+  Array [
+    Array [
+      "3",
+    ],
+  ],
+]
+`;
+
+exports[`ContentItemsModel gets series from specific channel a user has viewed: get percent complete 1`] = `
+Array [
+  Array [
+    Object {
+      "id": "1",
+    },
+  ],
+  Array [
+    Object {
+      "id": "2",
+    },
+  ],
+  Array [
+    Object {
+      "id": "3",
+    },
+  ],
+]
+`;
+
 exports[`ContentItemsModel gets the next item for a content series, based on different past interactions 1`] = `
 [MockFunction] {
   "calls": Array [

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -535,6 +535,7 @@ Array [
   Array [
     Array [
       "2",
+      "3",
     ],
   ],
 ]
@@ -564,6 +565,7 @@ exports[`ContentItemsModel gets series from specific channel a user has viewed: 
 Array [
   Array [
     Array [
+      "2",
       "3",
     ],
   ],

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
@@ -925,6 +925,33 @@ describe('ContentItemsModel', () => {
       'get percent complete'
     );
   });
+  it('gets series from specific channel a user has viewed', async () => {
+    const dataSource = new ContentItemsDataSource();
+    dataSource.get = jest.fn(() => Promise.resolve([{ id: 3 }]));
+    dataSource.getPercentComplete = jest.fn(({ id }) => (id === '1' ? 100 : 0));
+    dataSource.getFromIds = jest.fn();
+    dataSource.context = {
+      dataSources: {
+        Auth: { getCurrentPerson: () => ({ id: '1' }) },
+        Interactions: {
+          getInteractionsForCurrentUser: jest.fn(() =>
+            Promise.resolve([
+              { foreignKey: createGlobalId('1', 'UniversalContentItem') },
+              { foreignKey: createGlobalId('2', 'UniversalContentItem') },
+              { foreignKey: createGlobalId('2', 'UniversalContentItem') },
+              { foreignKey: createGlobalId('3', 'UniversalContentItem') },
+            ])
+          ),
+        },
+      },
+    };
+
+    await dataSource.getSeriesWithUserProgress({ channelIds: [10] });
+    expect(dataSource.getFromIds.mock.calls).toMatchSnapshot('get from ids');
+    expect(dataSource.getPercentComplete.mock.calls).toMatchSnapshot(
+      'get percent complete'
+    );
+  });
   it('gets an empty array fpr series a user has viewed without a user', async () => {
     const dataSource = new ContentItemsDataSource();
     dataSource.get = jest.fn(() => Promise.resolve([{ id: 3 }]));

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
@@ -16,6 +16,7 @@ ApollosConfig.loadJs({
   },
   ROCK_MAPPINGS: {
     SERMON_CHANNEL_ID: 'TEST_ID',
+    CAMPAIGN_CHANNEL_IDS: [1],
   },
   BIBLE_API: {
     BIBLE_ID: {
@@ -902,7 +903,7 @@ describe('ContentItemsModel', () => {
     const dataSource = new ContentItemsDataSource();
     dataSource.get = jest.fn(() => Promise.resolve([{ id: 3 }]));
     dataSource.getPercentComplete = jest.fn(({ id }) => (id === '1' ? 100 : 0));
-    dataSource.getFromIds = jest.fn();
+    dataSource.getFromIds = jest.fn(() => ({ andFilter: () => null }));
     dataSource.context = {
       dataSources: {
         Auth: { getCurrentPerson: () => ({ id: '1' }) },
@@ -929,7 +930,9 @@ describe('ContentItemsModel', () => {
     const dataSource = new ContentItemsDataSource();
     dataSource.get = jest.fn(() => Promise.resolve([{ id: 3 }]));
     dataSource.getPercentComplete = jest.fn(({ id }) => (id === '1' ? 100 : 0));
-    dataSource.getFromIds = jest.fn();
+    dataSource.getFromIds = jest.fn(() => ({
+      andFilter: () => ({ andFilter: () => null }),
+    }));
     dataSource.context = {
       dataSources: {
         Auth: { getCurrentPerson: () => ({ id: '1' }) },

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -547,25 +547,18 @@ export default class ContentItem extends RockApolloDataSource {
       .map(({ id }) => id);
 
     const inProgressIds = ids.filter((id) => ![...completedIds].includes(id));
+    let cursor = this.getFromIds(inProgressIds);
 
-    // whitelist only channels we've specified
-    if (channelIds) {
-      const whitelist = (await this.byContentChannelIds(channelIds).get()).map(
-        ({ id }) => `${id}`
-      );
-      const finalIds = inProgressIds.filter((id) =>
-        [...whitelist].includes(id)
-      );
-      return this.getFromIds(finalIds);
-    }
+    // only search through allowed channels
+    channelIds.forEach((id) => {
+      cursor = cursor.andFilter(`ContentChannelId eq ${id}`);
+    });
 
-    // blacklist certain series channels
-    // We need to make sure we don't include the campaign channels.
-    const blacklist = (await this.byContentChannelIds(
-      ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS
-    ).get()).map(({ id }) => `${id}`);
-    const finalIds = inProgressIds.filter((id) => ![...blacklist].includes(id));
-    return this.getFromIds(finalIds);
+    // exclude campaign channels
+    ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS.forEach((id) => {
+      cursor = cursor.andFilter(`ContentChannelId ne ${id}`);
+    });
+    return cursor;
   }
 
   async getPercentComplete({ id }) {

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -558,6 +558,7 @@ export default class ContentItem extends RockApolloDataSource {
     ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS.forEach((id) => {
       cursor = cursor.andFilter(`ContentChannelId ne ${id}`);
     });
+
     return cursor;
   }
 

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -516,7 +516,7 @@ export default class ContentItem extends RockApolloDataSource {
     return childItemsWithApollosIds[firstInteractedIndex - 1];
   }
 
-  async getSeriesWithUserProgress() {
+  async getSeriesWithUserProgress({ channelIds }) {
     const { Auth, Interactions } = this.context.dataSources;
 
     // Safely exit if we don't have a current user.
@@ -537,13 +537,6 @@ export default class ContentItem extends RockApolloDataSource {
       })
     );
 
-    // We need to make sure we don't include the campaign channels.
-    // We could also consider doing this using a whitelist.
-    // This also may be part of a broader conversation about how we identify the true parent of a content item
-    const blacklistedIds = (await this.byContentChannelIds(
-      ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS
-    ).get()).map(({ id }) => `${id}`);
-
     const completedIds = (await Promise.all(
       ids.map(async (id) => ({
         id,
@@ -553,10 +546,25 @@ export default class ContentItem extends RockApolloDataSource {
       .filter(({ percent }) => percent === 100)
       .map(({ id }) => id);
 
-    const finalIds = ids.filter(
-      (id) => ![...blacklistedIds, ...completedIds].includes(id)
-    );
+    const inProgressIds = ids.filter((id) => ![...completedIds].includes(id));
 
+    // whitelist only channels we've specified
+    if (channelIds) {
+      const whitelist = (await this.byContentChannelIds(channelIds).get()).map(
+        ({ id }) => `${id}`
+      );
+      const finalIds = inProgressIds.filter((id) =>
+        [...whitelist].includes(id)
+      );
+      return this.getFromIds(finalIds);
+    }
+
+    // blacklist certain series channels
+    // We need to make sure we don't include the campaign channels.
+    const blacklist = (await this.byContentChannelIds(
+      ROCK_MAPPINGS.CAMPAIGN_CHANNEL_IDS
+    ).get()).map(({ id }) => `${id}`);
+    const finalIds = inProgressIds.filter((id) => ![...blacklist].includes(id));
     return this.getFromIds(finalIds);
   }
 

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -516,7 +516,7 @@ export default class ContentItem extends RockApolloDataSource {
     return childItemsWithApollosIds[firstInteractedIndex - 1];
   }
 
-  async getSeriesWithUserProgress({ channelIds }) {
+  async getSeriesWithUserProgress({ channelIds = [] } = {}) {
     const { Auth, Interactions } = this.context.dataSources;
 
     // Safely exit if we don't have a current user.


### PR DESCRIPTION
This will let us specify which series channels we want to look through for progress items. So instead of including all sermon series _and_ devotional series by default, we can pick one.
