### PR TITLE
chore: Combines CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          regex: '[a-z]+(\([a-z]+\))?:.*' # Regex the title should match.
+          allowed_prefixes: 'chore,fix,feat,perf' # title should start with the given prefix
+          prefix_case_sensitive: false # title prefix are case insensitive
+          min_length: 10 # Min length of the title
+          max_length: 100 # Max length of the title
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node 10.19.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.19.x
+
+    - name: Install Yarn
+      run: npm install -g yarn
+
+    - name: Install Dependencies
+      run: yarn
+
+    - name: Lint
+      run: yarn lint
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node 10.19.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.19.x
+
+    - name: Install Yarn
+      run: npm install -g yarn
+
+    - name: Install Dependencies
+      run: yarn
+
+    - name: Jest
+      run: yarn test --stream -- -- --maxWorkers=2
+
+    - name: Codecov
+      uses: codecov/codecov-action@v1


### PR DESCRIPTION
This matches what we do in templates and fits with Github best practices by showing the correct job name, helpful for the CLI
