### PR TITLE
fix: Uppercase type support in create theme

### DIFF
--- a/packages/apollos-ui-kit/src/theme/createTheme.js
+++ b/packages/apollos-ui-kit/src/theme/createTheme.js
@@ -53,7 +53,7 @@ const createTheme = ({
   if (!availableTypes[theme.type])
     throw new Error(`The theme type ${theme.type} is not supported`);
 
-  merge(theme, availableTypes[typeInput], { colors: colorsInput });
+  merge(theme, availableTypes[theme.type], { colors: colorsInput });
 
   // mixin other theme defaults (that might depend on base theme)
   merge(theme, getDynamicThemePart(otherThemeDefaults, theme));

--- a/packages/apollos-ui-kit/src/theme/createTheme.tests.js
+++ b/packages/apollos-ui-kit/src/theme/createTheme.tests.js
@@ -46,6 +46,12 @@ describe('createTheme', () => {
     const theme = createTheme({ type: 'dark' });
     expect(theme).toMatchSnapshot();
   });
+  it('allows all caps theme names', () => {
+    const darkTheme = createTheme({ type: 'dark' });
+    const DARKTheme = createTheme({ type: 'DARK' });
+
+    expect(JSON.stringify(DARKTheme)).toEqual(JSON.stringify(darkTheme));
+  });
   it('throws an error for an unsupported theme type', () => {
     const theme = () => createTheme({ type: 'Boom' });
     expect(theme).toThrowErrorMatchingSnapshot();


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

it was technically supported before, except that there was a slight bug where it would try to merge in using the previous ALL CAPS theme type, instead of merging in the validated and transformed lowercase theme type.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
