### PR TITLE
fix: Adds support for @react-navigation onReady callback

### DIFF
--- a/packages/apollos-ui-kit/src/NavigationService/index.js
+++ b/packages/apollos-ui-kit/src/NavigationService/index.js
@@ -31,7 +31,6 @@ const setIsReady = () => {
 };
 
 const navigate = performWhenReady((...args) => {
-  console.log(...args, 'deese args');
   _navigator.navigate(...args);
 });
 

--- a/packages/apollos-ui-kit/src/NavigationService/index.js
+++ b/packages/apollos-ui-kit/src/NavigationService/index.js
@@ -1,12 +1,13 @@
 import { CommonActions } from '@react-navigation/native';
 
 let _navigator;
+let _ready = false;
 let _pendingActions = [];
 
 const getNavigator = () => _navigator;
 
 const performWhenReady = (func) => (...args) => {
-  if (_navigator) {
+  if (_navigator && _ready) {
     func(...args);
   } else {
     _pendingActions.push(() => func(...args));
@@ -15,13 +16,22 @@ const performWhenReady = (func) => (...args) => {
 
 const setTopLevelNavigator = (navigatorRef) => {
   _navigator = navigatorRef;
-  if (_pendingActions.length > 0) {
+  if (_pendingActions.length > 0 && _ready) {
     _pendingActions.forEach((action) => action());
+    _pendingActions = [];
   }
-  _pendingActions = [];
+};
+
+const setIsReady = () => {
+  _ready = true;
+  if (_pendingActions.length > 0 && _navigator) {
+    _pendingActions.forEach((action) => action());
+    _pendingActions = [];
+  }
 };
 
 const navigate = performWhenReady((...args) => {
+  console.log(...args, 'deese args');
   _navigator.navigate(...args);
 });
 
@@ -61,4 +71,5 @@ export default {
   resetToAuth,
   resetAction,
   getNavigator,
+  setIsReady,
 };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

We need a way to interface with this new `onReady` callback, otherwise we fire events from deep links before navigation has fully mounted. 

Usage example: 

![image](https://user-images.githubusercontent.com/1637694/106509935-3d3cc280-649c-11eb-923d-7420c7e175c5.png)


### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
