### PR TITLE
feat: Support swapping out NodeSingleInner component

### DIFF
--- a/packages/apollos-ui-connected/src/NodeSingleConnected/index.js
+++ b/packages/apollos-ui-connected/src/NodeSingleConnected/index.js
@@ -43,13 +43,13 @@ NodeSingleInner.propTypes = {
   ImageWrapperComponent: PropTypes.any, // eslint-disable-line
 };
 
-const NodeSingleConnected = ({ nodeId, children, ...props }) => (
+const NodeSingleConnected = ({ nodeId, children, Component, ...props }) => (
   <>
     <BackgroundView>
       <StretchyView>
         {({ Stretchy, ...scrollViewProps }) => (
           <FlexedScrollView {...scrollViewProps}>
-            <NodeSingleInner
+            <Component
               nodeId={nodeId}
               ImageWrapperComponent={Stretchy}
               {...props}
@@ -65,9 +65,19 @@ const NodeSingleConnected = ({ nodeId, children, ...props }) => (
 NodeSingleConnected.propTypes = {
   nodeId: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  Component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 };
 
-const NodeSingleConnectedWithMedia = ({ nodeId, children, ...props }) => (
+NodeSingleConnected.defaultProps = {
+  Component: NodeSingleInner,
+};
+
+const NodeSingleConnectedWithMedia = ({
+  nodeId,
+  children,
+  Component,
+  ...props
+}) => (
   <Query
     query={GET_MEDIA}
     variables={{ nodeId }}
@@ -93,7 +103,7 @@ const NodeSingleConnectedWithMedia = ({ nodeId, children, ...props }) => (
               title: data.node.title,
             }}
           >
-            <NodeSingleInner
+            <Component
               nodeId={nodeId}
               ImageWrapperComponent={Noop}
               {...props}
@@ -108,7 +118,12 @@ const NodeSingleConnectedWithMedia = ({ nodeId, children, ...props }) => (
 
 NodeSingleConnectedWithMedia.propTypes = {
   nodeId: PropTypes.string,
+  Component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+};
+
+NodeSingleConnectedWithMedia.defaultProps = {
+  Component: NodeSingleInner,
 };
 
 export default named('ui-connected.NodeSingleConnected')(


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Needed to add the sermon notes feature into Newspring without needing to copy the whole NodeSingleConnected component. This + `named` = 👍 

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
