### PR TITLE
feat: add scripture features to devotional content items

### DIFF
--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -19,6 +19,10 @@ const resolver = {
     featureFeed: ({ id }, args, { dataSources: { FeatureFeed } }) =>
       FeatureFeed.getFeed({ type: 'contentItem', args: { id } }),
   },
+  DevotionalContentItem: {
+    featureFeed: ({ id }, args, { dataSources: { FeatureFeed } }) =>
+      FeatureFeed.getFeed({ type: 'contentItem', args: { id } }),
+  },
   ContentSeriesContentItem: {
     featureFeed: ({ id }, args, { dataSources: { FeatureFeed } }) =>
       FeatureFeed.getFeed({ type: 'contentItem', args: { id } }),

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -76,7 +76,6 @@ export const interfacesSchema = gql`
 
   extend type MediaContentItem implements ScriptureNode
   extend type DevotionalContentItem implements ScriptureNode
-
   extend type ContentSeriesContentItem implements ProgressNode
 `;
 
@@ -958,6 +957,11 @@ export const featuresSchema = gql`
   }
 
   extend type WeekendContentItem implements FeaturesNode {
+    features: [Feature] @deprecated(reason: "Use featureFeed")
+    featureFeed: FeatureFeed
+  }
+
+  extend type DevotionalContentItem implements FeaturesNode {
     features: [Feature] @deprecated(reason: "Use featureFeed")
     featureFeed: FeatureFeed
   }


### PR DESCRIPTION
This is just to match the functionality of `WeekendContentItem`. We can deprecate content features later if we feel they are not the best method moving forward.
