### PR TITLE
fix: Add Comment Component Crashes on Android

### DIFF
--- a/packages/apollos-ui-connected/src/AddCommentFeatureConnected/__snapshots__/AddCommentFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/AddCommentFeatureConnected/__snapshots__/AddCommentFeatureConnected.tests.js.snap
@@ -13,13 +13,7 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "alignItems": "center",
-      "borderBottomWidth": 0.5,
-      "borderColor": "rgba(0, 0, 0, 0.1)",
-      "borderTopWidth": 0.5,
-      "flexDirection": "row",
       "opacity": 1,
-      "padding": 16,
     }
   }
 >
@@ -27,92 +21,63 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "height": 48,
-        "justifyContent": "center",
-        "width": 48,
+        "borderBottomWidth": 0.5,
+        "borderColor": "rgba(0, 0, 0, 0.1)",
+        "borderTopWidth": 0.5,
+        "flexDirection": "row",
+        "padding": 16,
       }
     }
-    themeSize={48}
   >
-    <RNSVGSvgView
-      align="xMidYMid"
-      bbHeight={52.5}
-      bbWidth={52.5}
-      height={52.5}
-      meetOrSlice={0}
-      minX={0}
-      minY={0}
+    <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "transparent",
-            "borderWidth": 0,
-          },
-          undefined,
-          null,
-          Object {
-            "flex": 0,
-            "height": 52,
-            "width": 52,
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "height": 48,
+          "justifyContent": "center",
+          "width": 48,
+        }
       }
       themeSize={48}
-      vbHeight={24}
-      vbWidth={24}
-      width={52.5}
     >
-      <RNSVGGroup
-        fill={
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={52.5}
+        bbWidth={52.5}
+        height={52.5}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        style={
           Array [
-            0,
-            4278190080,
+            Object {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            undefined,
+            null,
+            Object {
+              "flex": 0,
+              "height": 52,
+              "width": 52,
+            },
           ]
         }
-        fillOpacity={1}
-        fillRule={1}
-        font={Object {}}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
+        themeSize={48}
+        vbHeight={24}
+        vbWidth={24}
+        width={52.5}
       >
-        <RNSVGPath
-          d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-3.33 8.33C8.67 8.5 10.2 7 12 7s3.33 1.5 3.33 3.33v.84c0 1.84-1.53 3.33-3.33 3.33S8.67 13 8.67 11.17v-.84zm3.33 10c-2.03 0-3.9-.73-5.33-1.93.7-1.32 2.07-2.23 3.66-2.23h3.34c1.6 0 2.97.9 3.66 2.22-1.44 1.2-3.3 1.92-5.33 1.92z"
+        <RNSVGGroup
           fill={
             Array [
               0,
-              4289045925,
+              4278190080,
             ]
           }
           fillOpacity={1}
           fillRule={1}
+          font={Object {}}
           matrix={
             Array [
               1,
@@ -126,11 +91,7 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
           opacity={1}
           originX={0}
           originY={0}
-          propList={
-            Array [
-              "fill",
-            ]
-          }
+          propList={Array []}
           rotation={0}
           scaleX={1}
           scaleY={1}
@@ -147,135 +108,135 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
           vectorEffect={0}
           x={0}
           y={0}
-        />
-      </RNSVGGroup>
-    </RNSVGSvgView>
-    <View
-      style={
-        Object {
-          "bottom": 0,
-          "position": "absolute",
-          "right": 0,
-        }
-      }
-    >
+        >
+          <RNSVGPath
+            d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-3.33 8.33C8.67 8.5 10.2 7 12 7s3.33 1.5 3.33 3.33v.84c0 1.84-1.53 3.33-3.33 3.33S8.67 13 8.67 11.17v-.84zm3.33 10c-2.03 0-3.9-.73-5.33-1.93.7-1.32 2.07-2.23 3.66-2.23h3.34c1.6 0 2.97.9 3.66 2.22-1.44 1.2-3.3 1.92-5.33 1.92z"
+            fill={
+              Array [
+                0,
+                4289045925,
+              ]
+            }
+            fillOpacity={1}
+            fillRule={1}
+            matrix={
+              Array [
+                1,
+                0,
+                0,
+                1,
+                0,
+                0,
+              ]
+            }
+            opacity={1}
+            originX={0}
+            originY={0}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+            rotation={0}
+            scaleX={1}
+            scaleY={1}
+            skewX={0}
+            skewY={0}
+            stroke={null}
+            strokeDasharray={null}
+            strokeDashoffset={null}
+            strokeLinecap={0}
+            strokeLinejoin={0}
+            strokeMiterlimit={4}
+            strokeOpacity={1}
+            strokeWidth={1}
+            vectorEffect={0}
+            x={0}
+            y={0}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
       <View
-        accessible={true}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
+            "bottom": 0,
+            "position": "absolute",
+            "right": 0,
           }
         }
       >
         <View
-          borderRadius={24}
-          iconPadding={4.8}
+          accessible={true}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "backgroundColor": "#17B582",
-              "padding": 4.8,
-              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-              "shadowOffset": Object {
-                "height": 2,
-                "width": 0,
-              },
-              "shadowOpacity": 1,
-              "shadowRadius": 8,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
             }
           }
         >
-          <RNSVGSvgView
-            align="xMidYMid"
-            bbHeight={12}
-            bbWidth={12}
-            fill="none"
-            height={12}
-            meetOrSlice={0}
-            minX={0}
-            minY={0}
+          <View
+            borderRadius={24}
+            iconPadding={4.8}
             style={
-              Array [
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
+              Object {
+                "backgroundColor": "#17B582",
+                "padding": 4.8,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+                "shadowOffset": Object {
+                  "height": 2,
+                  "width": 0,
                 },
-                undefined,
-                Object {
-                  "opacity": 1,
-                },
-                Object {
-                  "flex": 0,
-                  "height": 12,
-                  "width": 12,
-                },
-              ]
+                "shadowOpacity": 1,
+                "shadowRadius": 8,
+              }
             }
-            vbHeight={10}
-            vbWidth={10}
-            width={12}
           >
-            <RNSVGGroup
-              fill={null}
-              fillOpacity={1}
-              fillRule={1}
-              font={Object {}}
-              matrix={
+            <RNSVGSvgView
+              align="xMidYMid"
+              bbHeight={12}
+              bbWidth={12}
+              fill="none"
+              height={12}
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
                 Array [
-                  1,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
+                  Object {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  undefined,
+                  Object {
+                    "opacity": 1,
+                  },
+                  Object {
+                    "flex": 0,
+                    "height": 12,
+                    "width": 12,
+                  },
                 ]
               }
-              opacity={1}
-              originX={0}
-              originY={0}
-              propList={
-                Array [
-                  "fill",
-                ]
-              }
-              rotation={0}
-              scaleX={1}
-              scaleY={1}
-              skewX={0}
-              skewY={0}
-              stroke={null}
-              strokeDasharray={null}
-              strokeDashoffset={null}
-              strokeLinecap={0}
-              strokeLinejoin={0}
-              strokeMiterlimit={4}
-              strokeOpacity={1}
-              strokeWidth={1}
-              vectorEffect={0}
-              x={0}
-              y={0}
+              vbHeight={10}
+              vbWidth={10}
+              width={12}
             >
-              <RNSVGPath
-                d="M1.5625 5H8.4375"
-                fill={
-                  Array [
-                    0,
-                    4278190080,
-                  ]
-                }
+              <RNSVGGroup
+                fill={null}
                 fillOpacity={1}
                 fillRule={1}
+                font={Object {}}
                 matrix={
                   Array [
                     1,
@@ -291,10 +252,7 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
                 originY={0}
                 propList={
                   Array [
-                    "stroke",
-                    "strokeWidth",
-                    "strokeLinecap",
-                    "strokeLinejoin",
+                    "fill",
                   ]
                 }
                 rotation={0}
@@ -302,94 +260,143 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
                 scaleY={1}
                 skewX={0}
                 skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    4294967295,
-                  ]
-                }
+                stroke={null}
                 strokeDasharray={null}
                 strokeDashoffset={null}
-                strokeLinecap={1}
-                strokeLinejoin={1}
+                strokeLinecap={0}
+                strokeLinejoin={0}
                 strokeMiterlimit={4}
                 strokeOpacity={1}
-                strokeWidth="2"
+                strokeWidth={1}
                 vectorEffect={0}
                 x={0}
                 y={0}
-              />
-              <RNSVGPath
-                d="M5 1.5625V8.4375"
-                fill={
-                  Array [
-                    0,
-                    4278190080,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
-                propList={
-                  Array [
-                    "stroke",
-                    "strokeWidth",
-                    "strokeLinecap",
-                    "strokeLinejoin",
-                  ]
-                }
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    4294967295,
-                  ]
-                }
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={1}
-                strokeLinejoin={1}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth="2"
-                vectorEffect={0}
-                x={0}
-                y={0}
-              />
-            </RNSVGGroup>
-          </RNSVGSvgView>
+              >
+                <RNSVGPath
+                  d="M1.5625 5H8.4375"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={
+                    Array [
+                      0,
+                      4294967295,
+                    ]
+                  }
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth="2"
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+                <RNSVGPath
+                  d="M5 1.5625V8.4375"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={
+                    Array [
+                      0,
+                      4294967295,
+                    ]
+                  }
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth="2"
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
         </View>
       </View>
     </View>
-  </View>
-  <Text
-    style={
-      Object {
-        "color": "#303030",
-        "fontFamily": "InterUI-Medium",
-        "fontSize": 14,
-        "lineHeight": 21,
-        "padding": 8,
+    <Text
+      style={
+        Object {
+          "color": "#303030",
+          "fontFamily": "InterUI-Medium",
+          "fontSize": 14,
+          "lineHeight": 21,
+          "padding": 8,
+        }
       }
-    }
-  >
-    A great initial prompt
-  </Text>
+    >
+      A great initial prompt
+    </Text>
+  </View>
 </View>
 `;

--- a/packages/apollos-ui-kit/src/AddCommentInput/AddCommentInput.js
+++ b/packages/apollos-ui-kit/src/AddCommentInput/AddCommentInput.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, TextInput } from 'react-native';
+import { StyleSheet, TextInput, View } from 'react-native';
 import PropTypes from 'prop-types';
 import styled from '../styled';
 import { H4, H5, BodySmall } from '../typography';
@@ -31,7 +31,7 @@ const AddCommentContainer = styled(
     alignItems: 'center',
   }),
   'ui-kit.AddCommentInput.AddCommentContainer'
-)(Touchable);
+)(View);
 
 const NextButton = styled(
   ({ theme: { colors } }) => ({
@@ -92,10 +92,12 @@ const AddCommentInput = ({ initialPrompt, addPrompt, onSubmit, profile }) => {
       </NextButtonTouchable>
     </CommentInputContainer>
   ) : (
-    <AddCommentContainer onPress={onStartWriting}>
-      <CommentAvatar source={profile?.image} />
-      <AddCommentPrompt>{currentText || initialPrompt}</AddCommentPrompt>
-    </AddCommentContainer>
+    <Touchable onPress={onStartWriting}>
+      <AddCommentContainer>
+        <CommentAvatar source={profile?.image} />
+        <AddCommentPrompt>{currentText || initialPrompt}</AddCommentPrompt>
+      </AddCommentContainer>
+    </Touchable>
   );
 };
 

--- a/packages/apollos-ui-kit/src/AddCommentInput/__snapshots__/AddCommentInput.tests.js.snap
+++ b/packages/apollos-ui-kit/src/AddCommentInput/__snapshots__/AddCommentInput.tests.js.snap
@@ -13,13 +13,7 @@ exports[`The AddCommentInput Component must render 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "alignItems": "center",
-      "borderBottomWidth": 0.5,
-      "borderColor": "rgba(0, 0, 0, 0.1)",
-      "borderTopWidth": 0.5,
-      "flexDirection": "row",
       "opacity": 1,
-      "padding": 16,
     }
   }
 >
@@ -27,165 +21,132 @@ exports[`The AddCommentInput Component must render 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "height": 48,
-        "justifyContent": "center",
-        "width": 48,
+        "borderBottomWidth": 0.5,
+        "borderColor": "rgba(0, 0, 0, 0.1)",
+        "borderTopWidth": 0.5,
+        "flexDirection": "row",
+        "padding": 16,
       }
     }
-    themeSize={48}
   >
-    <Image
-      fadeDuration={250}
-      onLoad={[Function]}
-      source={
-        Array [
-          Object {
-            "cache": "force-cache",
-            "uri": "https://picsum.photos/200",
-          },
-        ]
-      }
-      style={
-        Object {
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 24,
-          "bottom": 0,
-          "height": "100%",
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "width": "100%",
-        }
-      }
-      themeSize={48}
-    />
     <View
       style={
         Object {
-          "bottom": 0,
-          "position": "absolute",
-          "right": 0,
+          "alignItems": "center",
+          "height": 48,
+          "justifyContent": "center",
+          "width": 48,
         }
       }
+      themeSize={48}
     >
-      <View
-        accessible={true}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+      <Image
+        fadeDuration={250}
+        onLoad={[Function]}
+        source={
+          Array [
+            Object {
+              "cache": "force-cache",
+              "uri": "https://picsum.photos/200",
+            },
+          ]
+        }
         style={
           Object {
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 24,
+            "bottom": 0,
+            "height": "100%",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "100%",
+          }
+        }
+        themeSize={48}
+      />
+      <View
+        style={
+          Object {
+            "bottom": 0,
+            "position": "absolute",
+            "right": 0,
           }
         }
       >
         <View
-          borderRadius={24}
-          iconPadding={4.8}
+          accessible={true}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "backgroundColor": "#17B582",
-              "padding": 4.8,
-              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-              "shadowOffset": Object {
-                "height": 2,
-                "width": 0,
-              },
-              "shadowOpacity": 1,
-              "shadowRadius": 8,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
             }
           }
         >
-          <RNSVGSvgView
-            align="xMidYMid"
-            bbHeight={12}
-            bbWidth={12}
-            fill="none"
-            height={12}
-            meetOrSlice={0}
-            minX={0}
-            minY={0}
+          <View
+            borderRadius={24}
+            iconPadding={4.8}
             style={
-              Array [
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
+              Object {
+                "backgroundColor": "#17B582",
+                "padding": 4.8,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+                "shadowOffset": Object {
+                  "height": 2,
+                  "width": 0,
                 },
-                undefined,
-                Object {
-                  "opacity": 1,
-                },
-                Object {
-                  "flex": 0,
-                  "height": 12,
-                  "width": 12,
-                },
-              ]
+                "shadowOpacity": 1,
+                "shadowRadius": 8,
+              }
             }
-            vbHeight={10}
-            vbWidth={10}
-            width={12}
           >
-            <RNSVGGroup
-              fill={null}
-              fillOpacity={1}
-              fillRule={1}
-              font={Object {}}
-              matrix={
+            <RNSVGSvgView
+              align="xMidYMid"
+              bbHeight={12}
+              bbWidth={12}
+              fill="none"
+              height={12}
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
                 Array [
-                  1,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
+                  Object {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  undefined,
+                  Object {
+                    "opacity": 1,
+                  },
+                  Object {
+                    "flex": 0,
+                    "height": 12,
+                    "width": 12,
+                  },
                 ]
               }
-              opacity={1}
-              originX={0}
-              originY={0}
-              propList={
-                Array [
-                  "fill",
-                ]
-              }
-              rotation={0}
-              scaleX={1}
-              scaleY={1}
-              skewX={0}
-              skewY={0}
-              stroke={null}
-              strokeDasharray={null}
-              strokeDashoffset={null}
-              strokeLinecap={0}
-              strokeLinejoin={0}
-              strokeMiterlimit={4}
-              strokeOpacity={1}
-              strokeWidth={1}
-              vectorEffect={0}
-              x={0}
-              y={0}
+              vbHeight={10}
+              vbWidth={10}
+              width={12}
             >
-              <RNSVGPath
-                d="M1.5625 5H8.4375"
-                fill={
-                  Array [
-                    0,
-                    4278190080,
-                  ]
-                }
+              <RNSVGGroup
+                fill={null}
                 fillOpacity={1}
                 fillRule={1}
+                font={Object {}}
                 matrix={
                   Array [
                     1,
@@ -201,10 +162,7 @@ exports[`The AddCommentInput Component must render 1`] = `
                 originY={0}
                 propList={
                   Array [
-                    "stroke",
-                    "strokeWidth",
-                    "strokeLinecap",
-                    "strokeLinejoin",
+                    "fill",
                   ]
                 }
                 rotation={0}
@@ -212,95 +170,144 @@ exports[`The AddCommentInput Component must render 1`] = `
                 scaleY={1}
                 skewX={0}
                 skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    4294967295,
-                  ]
-                }
+                stroke={null}
                 strokeDasharray={null}
                 strokeDashoffset={null}
-                strokeLinecap={1}
-                strokeLinejoin={1}
+                strokeLinecap={0}
+                strokeLinejoin={0}
                 strokeMiterlimit={4}
                 strokeOpacity={1}
-                strokeWidth="2"
+                strokeWidth={1}
                 vectorEffect={0}
                 x={0}
                 y={0}
-              />
-              <RNSVGPath
-                d="M5 1.5625V8.4375"
-                fill={
-                  Array [
-                    0,
-                    4278190080,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
-                propList={
-                  Array [
-                    "stroke",
-                    "strokeWidth",
-                    "strokeLinecap",
-                    "strokeLinejoin",
-                  ]
-                }
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    4294967295,
-                  ]
-                }
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={1}
-                strokeLinejoin={1}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth="2"
-                vectorEffect={0}
-                x={0}
-                y={0}
-              />
-            </RNSVGGroup>
-          </RNSVGSvgView>
+              >
+                <RNSVGPath
+                  d="M1.5625 5H8.4375"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={
+                    Array [
+                      0,
+                      4294967295,
+                    ]
+                  }
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth="2"
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+                <RNSVGPath
+                  d="M5 1.5625V8.4375"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={
+                    Array [
+                      0,
+                      4294967295,
+                    ]
+                  }
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth="2"
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
         </View>
       </View>
     </View>
-  </View>
-  <Text
-    style={
-      Object {
-        "color": "#303030",
-        "fontFamily": "InterUI-Medium",
-        "fontSize": 14,
-        "lineHeight": 21,
-        "padding": 8,
+    <Text
+      style={
+        Object {
+          "color": "#303030",
+          "fontFamily": "InterUI-Medium",
+          "fontSize": 14,
+          "lineHeight": 21,
+          "padding": 8,
+        }
       }
-    }
-  >
-    Write Something...
-  </Text>
+    >
+      Write Something...
+    </Text>
+  </View>
 </View>
 `;
 
@@ -317,13 +324,7 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Object {
-      "alignItems": "center",
-      "borderBottomWidth": 0.5,
-      "borderColor": "rgba(0, 0, 0, 0.1)",
-      "borderTopWidth": 0.5,
-      "flexDirection": "row",
       "opacity": 1,
-      "padding": 16,
     }
   }
 >
@@ -331,92 +332,63 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "height": 48,
-        "justifyContent": "center",
-        "width": 48,
+        "borderBottomWidth": 0.5,
+        "borderColor": "rgba(0, 0, 0, 0.1)",
+        "borderTopWidth": 0.5,
+        "flexDirection": "row",
+        "padding": 16,
       }
     }
-    themeSize={48}
   >
-    <RNSVGSvgView
-      align="xMidYMid"
-      bbHeight={52.5}
-      bbWidth={52.5}
-      height={52.5}
-      meetOrSlice={0}
-      minX={0}
-      minY={0}
+    <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "transparent",
-            "borderWidth": 0,
-          },
-          undefined,
-          null,
-          Object {
-            "flex": 0,
-            "height": 52,
-            "width": 52,
-          },
-        ]
+        Object {
+          "alignItems": "center",
+          "height": 48,
+          "justifyContent": "center",
+          "width": 48,
+        }
       }
       themeSize={48}
-      vbHeight={24}
-      vbWidth={24}
-      width={52.5}
     >
-      <RNSVGGroup
-        fill={
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={52.5}
+        bbWidth={52.5}
+        height={52.5}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        style={
           Array [
-            0,
-            4278190080,
+            Object {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            undefined,
+            null,
+            Object {
+              "flex": 0,
+              "height": 52,
+              "width": 52,
+            },
           ]
         }
-        fillOpacity={1}
-        fillRule={1}
-        font={Object {}}
-        matrix={
-          Array [
-            1,
-            0,
-            0,
-            1,
-            0,
-            0,
-          ]
-        }
-        opacity={1}
-        originX={0}
-        originY={0}
-        propList={Array []}
-        rotation={0}
-        scaleX={1}
-        scaleY={1}
-        skewX={0}
-        skewY={0}
-        stroke={null}
-        strokeDasharray={null}
-        strokeDashoffset={null}
-        strokeLinecap={0}
-        strokeLinejoin={0}
-        strokeMiterlimit={4}
-        strokeOpacity={1}
-        strokeWidth={1}
-        vectorEffect={0}
-        x={0}
-        y={0}
+        themeSize={48}
+        vbHeight={24}
+        vbWidth={24}
+        width={52.5}
       >
-        <RNSVGPath
-          d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-3.33 8.33C8.67 8.5 10.2 7 12 7s3.33 1.5 3.33 3.33v.84c0 1.84-1.53 3.33-3.33 3.33S8.67 13 8.67 11.17v-.84zm3.33 10c-2.03 0-3.9-.73-5.33-1.93.7-1.32 2.07-2.23 3.66-2.23h3.34c1.6 0 2.97.9 3.66 2.22-1.44 1.2-3.3 1.92-5.33 1.92z"
+        <RNSVGGroup
           fill={
             Array [
               0,
-              4289045925,
+              4278190080,
             ]
           }
           fillOpacity={1}
           fillRule={1}
+          font={Object {}}
           matrix={
             Array [
               1,
@@ -430,11 +402,7 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
           opacity={1}
           originX={0}
           originY={0}
-          propList={
-            Array [
-              "fill",
-            ]
-          }
+          propList={Array []}
           rotation={0}
           scaleX={1}
           scaleY={1}
@@ -451,135 +419,135 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
           vectorEffect={0}
           x={0}
           y={0}
-        />
-      </RNSVGGroup>
-    </RNSVGSvgView>
-    <View
-      style={
-        Object {
-          "bottom": 0,
-          "position": "absolute",
-          "right": 0,
-        }
-      }
-    >
+        >
+          <RNSVGPath
+            d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-3.33 8.33C8.67 8.5 10.2 7 12 7s3.33 1.5 3.33 3.33v.84c0 1.84-1.53 3.33-3.33 3.33S8.67 13 8.67 11.17v-.84zm3.33 10c-2.03 0-3.9-.73-5.33-1.93.7-1.32 2.07-2.23 3.66-2.23h3.34c1.6 0 2.97.9 3.66 2.22-1.44 1.2-3.3 1.92-5.33 1.92z"
+            fill={
+              Array [
+                0,
+                4289045925,
+              ]
+            }
+            fillOpacity={1}
+            fillRule={1}
+            matrix={
+              Array [
+                1,
+                0,
+                0,
+                1,
+                0,
+                0,
+              ]
+            }
+            opacity={1}
+            originX={0}
+            originY={0}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+            rotation={0}
+            scaleX={1}
+            scaleY={1}
+            skewX={0}
+            skewY={0}
+            stroke={null}
+            strokeDasharray={null}
+            strokeDashoffset={null}
+            strokeLinecap={0}
+            strokeLinejoin={0}
+            strokeMiterlimit={4}
+            strokeOpacity={1}
+            strokeWidth={1}
+            vectorEffect={0}
+            x={0}
+            y={0}
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
       <View
-        accessible={true}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
+            "bottom": 0,
+            "position": "absolute",
+            "right": 0,
           }
         }
       >
         <View
-          borderRadius={24}
-          iconPadding={4.8}
+          accessible={true}
+          focusable={false}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "backgroundColor": "#17B582",
-              "padding": 4.8,
-              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-              "shadowOffset": Object {
-                "height": 2,
-                "width": 0,
-              },
-              "shadowOpacity": 1,
-              "shadowRadius": 8,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
             }
           }
         >
-          <RNSVGSvgView
-            align="xMidYMid"
-            bbHeight={12}
-            bbWidth={12}
-            fill="none"
-            height={12}
-            meetOrSlice={0}
-            minX={0}
-            minY={0}
+          <View
+            borderRadius={24}
+            iconPadding={4.8}
             style={
-              Array [
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
+              Object {
+                "backgroundColor": "#17B582",
+                "padding": 4.8,
+                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+                "shadowOffset": Object {
+                  "height": 2,
+                  "width": 0,
                 },
-                undefined,
-                Object {
-                  "opacity": 1,
-                },
-                Object {
-                  "flex": 0,
-                  "height": 12,
-                  "width": 12,
-                },
-              ]
+                "shadowOpacity": 1,
+                "shadowRadius": 8,
+              }
             }
-            vbHeight={10}
-            vbWidth={10}
-            width={12}
           >
-            <RNSVGGroup
-              fill={null}
-              fillOpacity={1}
-              fillRule={1}
-              font={Object {}}
-              matrix={
+            <RNSVGSvgView
+              align="xMidYMid"
+              bbHeight={12}
+              bbWidth={12}
+              fill="none"
+              height={12}
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
                 Array [
-                  1,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
+                  Object {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  undefined,
+                  Object {
+                    "opacity": 1,
+                  },
+                  Object {
+                    "flex": 0,
+                    "height": 12,
+                    "width": 12,
+                  },
                 ]
               }
-              opacity={1}
-              originX={0}
-              originY={0}
-              propList={
-                Array [
-                  "fill",
-                ]
-              }
-              rotation={0}
-              scaleX={1}
-              scaleY={1}
-              skewX={0}
-              skewY={0}
-              stroke={null}
-              strokeDasharray={null}
-              strokeDashoffset={null}
-              strokeLinecap={0}
-              strokeLinejoin={0}
-              strokeMiterlimit={4}
-              strokeOpacity={1}
-              strokeWidth={1}
-              vectorEffect={0}
-              x={0}
-              y={0}
+              vbHeight={10}
+              vbWidth={10}
+              width={12}
             >
-              <RNSVGPath
-                d="M1.5625 5H8.4375"
-                fill={
-                  Array [
-                    0,
-                    4278190080,
-                  ]
-                }
+              <RNSVGGroup
+                fill={null}
                 fillOpacity={1}
                 fillRule={1}
+                font={Object {}}
                 matrix={
                   Array [
                     1,
@@ -595,10 +563,7 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
                 originY={0}
                 propList={
                   Array [
-                    "stroke",
-                    "strokeWidth",
-                    "strokeLinecap",
-                    "strokeLinejoin",
+                    "fill",
                   ]
                 }
                 rotation={0}
@@ -606,94 +571,143 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
                 scaleY={1}
                 skewX={0}
                 skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    4294967295,
-                  ]
-                }
+                stroke={null}
                 strokeDasharray={null}
                 strokeDashoffset={null}
-                strokeLinecap={1}
-                strokeLinejoin={1}
+                strokeLinecap={0}
+                strokeLinejoin={0}
                 strokeMiterlimit={4}
                 strokeOpacity={1}
-                strokeWidth="2"
+                strokeWidth={1}
                 vectorEffect={0}
                 x={0}
                 y={0}
-              />
-              <RNSVGPath
-                d="M5 1.5625V8.4375"
-                fill={
-                  Array [
-                    0,
-                    4278190080,
-                  ]
-                }
-                fillOpacity={1}
-                fillRule={1}
-                matrix={
-                  Array [
-                    1,
-                    0,
-                    0,
-                    1,
-                    0,
-                    0,
-                  ]
-                }
-                opacity={1}
-                originX={0}
-                originY={0}
-                propList={
-                  Array [
-                    "stroke",
-                    "strokeWidth",
-                    "strokeLinecap",
-                    "strokeLinejoin",
-                  ]
-                }
-                rotation={0}
-                scaleX={1}
-                scaleY={1}
-                skewX={0}
-                skewY={0}
-                stroke={
-                  Array [
-                    0,
-                    4294967295,
-                  ]
-                }
-                strokeDasharray={null}
-                strokeDashoffset={null}
-                strokeLinecap={1}
-                strokeLinejoin={1}
-                strokeMiterlimit={4}
-                strokeOpacity={1}
-                strokeWidth="2"
-                vectorEffect={0}
-                x={0}
-                y={0}
-              />
-            </RNSVGGroup>
-          </RNSVGSvgView>
+              >
+                <RNSVGPath
+                  d="M1.5625 5H8.4375"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={
+                    Array [
+                      0,
+                      4294967295,
+                    ]
+                  }
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth="2"
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+                <RNSVGPath
+                  d="M5 1.5625V8.4375"
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={
+                    Array [
+                      "stroke",
+                      "strokeWidth",
+                      "strokeLinecap",
+                      "strokeLinejoin",
+                    ]
+                  }
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={
+                    Array [
+                      0,
+                      4294967295,
+                    ]
+                  }
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={1}
+                  strokeLinejoin={1}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth="2"
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
         </View>
       </View>
     </View>
-  </View>
-  <Text
-    style={
-      Object {
-        "color": "#303030",
-        "fontFamily": "InterUI-Medium",
-        "fontSize": 14,
-        "lineHeight": 21,
-        "padding": 8,
+    <Text
+      style={
+        Object {
+          "color": "#303030",
+          "fontFamily": "InterUI-Medium",
+          "fontSize": 14,
+          "lineHeight": 21,
+          "padding": 8,
+        }
       }
-    }
-  >
-    Write Something...
-  </Text>
+    >
+      Write Something...
+    </Text>
+  </View>
 </View>
 `;


### PR DESCRIPTION
## DESCRIPTION

The AddComment Component was crashing because `Touchables` on Android can't have more than a single child. I refactored the component so that there's an inner view (containing the styles) 

<img width="703" alt="Screen Shot 2021-02-12 at 8 30 51 AM" src="https://user-images.githubusercontent.com/1637694/107779192-02941f00-6d13-11eb-8f4c-980c78809070.png">
<img width="538" alt="Screen Shot 2021-02-12 at 9 17 28 AM" src="https://user-images.githubusercontent.com/1637694/107779292-26576500-6d13-11eb-8713-dec0da8c4533.png">


### What does this PR do, or why is it needed?

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
