### PR TITLE
chore: remove URL from interaction data

### DIFF
--- a/packages/apollos-data-connector-rock/src/followings/__tests__/resolvers.tests.js
+++ b/packages/apollos-data-connector-rock/src/followings/__tests__/resolvers.tests.js
@@ -107,9 +107,6 @@ ApollosConfig.loadJs({
       'MediaContentItem',
     ],
   },
-  APP: {
-    DEEP_LINK_HOST: 'apolloschurch',
-  },
 });
 
 describe('Following', () => {

--- a/packages/apollos-data-connector-rock/src/interactions/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/interactions/__tests__/__snapshots__/data-source.tests.js.snap
@@ -42,7 +42,7 @@ Array [
     "/Interactions",
     Object {
       "InteractionComponentId": 789,
-      "InteractionData": "apolloschurch://Interactions/ContentSingle?itemId=UniversalContentItem:559b23fd0aa90e81b1c023e72e230fa1",
+      "InteractionData": "UniversalContentItem:559b23fd0aa90e81b1c023e72e230fa1",
       "InteractionSummary": "Like - Super Cool Content",
       "Operation": "Like",
       "PersonAliasId": 456,

--- a/packages/apollos-data-connector-rock/src/interactions/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/interactions/__tests__/data-source.tests.js
@@ -12,9 +12,6 @@ ApollosConfig.loadJs({
     IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
     USE_PLUGIN: true,
   },
-  APP: {
-    DEEP_LINK_HOST: 'apolloschurch',
-  },
 });
 
 const ds = new Interactions();

--- a/packages/apollos-data-connector-rock/src/interactions/data-source.js
+++ b/packages/apollos-data-connector-rock/src/interactions/data-source.js
@@ -94,7 +94,7 @@ export default class Interactions extends RockApolloDataSource {
       Operation: operationName,
       InteractionDateTime: new Date().toJSON(),
       InteractionSummary: `${operationName} - ${itemTitle}`,
-      InteractionData: `${ApollosConfig.APP.DEEP_LINK_HOST}://Interactions/ContentSingle?itemId=${itemId}`,
+      InteractionData: `${itemId}`,
     });
 
     return this.get(`/Interactions/${interactionId}`);


### PR DESCRIPTION
This will allow us to remove an unneeded variable from the config yml. Not sure the original purpose of throwing the interaction data in there like that
