### PR TITLE
chore: remove need for Rock share URL

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
@@ -6,11 +6,13 @@ import { buildGetMock } from '../../test-utils';
 import ContentItemsDataSource from '../data-source';
 
 ApollosConfig.loadJs({
+  APP: {
+    ROOT_API_URL: 'https://apollos.api',
+  },
   ROCK: {
     API_URL: 'https://apollosrock.newspring.cc/api',
     API_TOKEN: 'some-rock-token',
     IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
-    SHARE_URL: 'https://apollosrock.newspring.cc',
     TIMEZONE: 'America/New_York',
     USE_PLUGIN: true,
   },

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -15,6 +15,7 @@ import { createImageUrlFromGuid } from '../utils';
 
 const {
   APP: { ROOT_API_URL },
+  ROCK,
   ROCK_MAPPINGS,
   ROCK_CONSTANTS,
 } = ApollosConfig;

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -13,7 +13,11 @@ import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
 
 import { createImageUrlFromGuid } from '../utils';
 
-const { ROCK, ROCK_MAPPINGS, ROCK_CONSTANTS } = ApollosConfig;
+const {
+  APP: { ROOT_API_URL },
+  ROCK_MAPPINGS,
+  ROCK_CONSTANTS,
+} = ApollosConfig;
 
 export default class ContentItem extends RockApolloDataSource {
   resource = 'ContentChannelItems';
@@ -231,7 +235,7 @@ export default class ContentItem extends RockApolloDataSource {
       channelId
     );
 
-    if (!contentChannel.itemUrl) return ROCK.SHARE_URL;
+    if (!contentChannel.itemUrl) return ROOT_API_URL;
 
     const slug = await this.request('ContentChannelItemSlugs')
       .filter(`ContentChannelItemId eq ${contentId}`)
@@ -239,7 +243,7 @@ export default class ContentItem extends RockApolloDataSource {
       .first();
 
     return [
-      ROCK.SHARE_URL,
+      ROOT_API_URL,
       contentChannel.itemUrl.replace(/^\//, ''),
       slug ? slug.slug : '',
     ].join('/');

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -13,12 +13,7 @@ import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
 
 import { createImageUrlFromGuid } from '../utils';
 
-const {
-  APP: { ROOT_API_URL },
-  ROCK,
-  ROCK_MAPPINGS,
-  ROCK_CONSTANTS,
-} = ApollosConfig;
+const { APP, ROCK, ROCK_MAPPINGS, ROCK_CONSTANTS } = ApollosConfig;
 
 export default class ContentItem extends RockApolloDataSource {
   resource = 'ContentChannelItems';
@@ -236,7 +231,7 @@ export default class ContentItem extends RockApolloDataSource {
       channelId
     );
 
-    if (!contentChannel.itemUrl) return ROOT_API_URL;
+    if (!contentChannel.itemUrl) return APP.ROOT_API_URL;
 
     const slug = await this.request('ContentChannelItemSlugs')
       .filter(`ContentChannelItemId eq ${contentId}`)
@@ -244,7 +239,7 @@ export default class ContentItem extends RockApolloDataSource {
       .first();
 
     return [
-      ROOT_API_URL,
+      APP.ROOT_API_URL,
       contentChannel.itemUrl.replace(/^\//, ''),
       slug ? slug.slug : '',
     ].join('/');

--- a/packages/apollos-data-connector-rock/src/events/__tests__/data-source.test.js
+++ b/packages/apollos-data-connector-rock/src/events/__tests__/data-source.test.js
@@ -2,11 +2,13 @@ import ApollosConfig from '@apollosproject/config';
 import EventsDataSource from '../data-source';
 
 ApollosConfig.loadJs({
+  APP: {
+    ROOT_API_URL: 'https://apollos.api',
+  },
   ROCK: {
     API_URL: 'https://apollosrock.newspring.cc/api',
     API_TOKEN: 'some-rock-token',
     IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
-    SHARE_URL: 'https://apollosrock.newspring.cc',
     TIMEZONE: 'America/New_York',
   },
   ROCK_MAPPINGS: {


### PR DESCRIPTION
Don't really need this variable, it makes more sense and is served better from `APP.ROOT_API_URL`
