### PR TITLE
fix: remove comment list query fragment

### DIFF
--- a/packages/apollos-ui-fragments/src/features.js
+++ b/packages/apollos-ui-fragments/src/features.js
@@ -113,9 +113,6 @@ const LITE_FEATURES_FRAGMENT = gql`
       title
       url
     }
-    ... on CommentListFeature {
-      id
-    }
   }
 `;
 


### PR DESCRIPTION
This will let us remove the need for including the comments schema before churches are ready for all the baggage that comes with the postgres data connector. This should be fine because we are already pulling the `id` above the specific types
