### PR TITLE
fix: Button padding on Auth Onboarding

### DIFF
--- a/packages/apollos-ui-auth/src/Password/PasswordEntry.js
+++ b/packages/apollos-ui-auth/src/Password/PasswordEntry.js
@@ -1,12 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  KeyboardAvoidingView,
-  StyleSheet,
-  ScrollView,
-  Platform,
-  StatusBar,
-} from 'react-native';
+import { ScrollView, Platform } from 'react-native';
 import { get } from 'lodash';
 import {
   PaddedView,
@@ -15,8 +9,14 @@ import {
   ButtonLink,
   BackgroundView,
 } from '@apollosproject/ui-kit';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { FlexedSafeAreaView, TitleText, PromptText } from '../styles';
+import {
+  FlexedSafeAreaView,
+  TitleText,
+  PromptText,
+  FlexedKeyboardAvoidingView,
+} from '../styles';
 
 const PasswordEntry = ({
   passwordTitleText,
@@ -31,61 +31,64 @@ const PasswordEntry = ({
   values,
   BackgroundComponent,
   newUser,
-}) => (
-  <KeyboardAvoidingView
-    style={StyleSheet.absoluteFill}
-    behavior={'padding'}
-    keyboardVerticalOffset={
-      Platform.OS === 'android' ? StatusBar.currentHeight : 0
-    }
-  >
+}) => {
+  // We need to  the avoiding view by by header height on iOS so the button doesn't appear under the keyboard.
+  // https://github.com/software-mansion/react-native-screens/blob/bcd5e4d8ea861b78bff7747162e6df7163ed4e1f/createNativeStackNavigator/README.md
+  const statusBarInset = useSafeAreaInsets().top; // inset of the status bar
+  const headerInset = statusBarInset + 44; // inset to use for a small header since it's frame is equal to 44 + the frame of status bar
+  return (
     <BackgroundComponent>
-      <FlexedSafeAreaView>
-        <ScrollView>
-          <PaddedView>
-            <TitleText>{passwordTitleText}</TitleText>
-            <PromptText padded>
-              {newUser ? passwordPromptTextNewUser : passwordPromptText}
-            </PromptText>
+      <FlexedSafeAreaView edges={['right', 'top', 'left']}>
+        <FlexedKeyboardAvoidingView
+          behavior={'padding'}
+          keyboardVerticalOffset={Platform.OS === 'ios' ? headerInset : 0}
+        >
+          <ScrollView>
+            <PaddedView>
+              <TitleText>{passwordTitleText}</TitleText>
+              <PromptText padded>
+                {newUser ? passwordPromptTextNewUser : passwordPromptText}
+              </PromptText>
 
-            <TextInput
-              autoFocus
-              autoComplete={'password'}
-              label={'Password'}
-              type={'password'}
-              textContentType="password"
-              enablesReturnKeyAutomatically
-              returnKeyType={'next'}
-              onSubmitEditing={onPressNext}
-              error={get(errors, 'password')}
-              onChangeText={(text) => setFieldValue('password', text)}
-              value={get(values, 'password')}
-            />
+              <TextInput
+                autoFocus
+                autoComplete={'password'}
+                label={'Password'}
+                type={'password'}
+                textContentType="password"
+                enablesReturnKeyAutomatically
+                returnKeyType={'next'}
+                onSubmitEditing={onPressNext}
+                error={get(errors, 'password')}
+                onChangeText={(text) => setFieldValue('password', text)}
+                value={get(values, 'password')}
+              />
 
-            {handleForgotPassword ? (
-              <ButtonLink onPress={handleForgotPassword}>
-                Forgot your password?
-              </ButtonLink>
-            ) : null}
-          </PaddedView>
-        </ScrollView>
+              {handleForgotPassword ? (
+                <ButtonLink onPress={handleForgotPassword}>
+                  Forgot your password?
+                </ButtonLink>
+              ) : null}
+            </PaddedView>
+          </ScrollView>
 
-        {onPressNext ? (
-          <PaddedView>
-            <Button
-              onPress={onPressNext}
-              disabled={disabled}
-              loading={isLoading}
-              title={'Login'}
-              type={'primary'}
-              pill={false}
-            />
-          </PaddedView>
-        ) : null}
+          {onPressNext ? (
+            <PaddedView>
+              <Button
+                onPress={onPressNext}
+                disabled={disabled}
+                loading={isLoading}
+                title={'Login'}
+                type={'primary'}
+                pill={false}
+              />
+            </PaddedView>
+          ) : null}
+        </FlexedKeyboardAvoidingView>
       </FlexedSafeAreaView>
     </BackgroundComponent>
-  </KeyboardAvoidingView>
-);
+  );
+};
 
 PasswordEntry.propTypes = {
   passwordTitleText: PropTypes.string,

--- a/packages/apollos-ui-auth/src/Password/__snapshots__/PasswordEntryConnected.tests.js.snap
+++ b/packages/apollos-ui-auth/src/Password/__snapshots__/PasswordEntryConnected.tests.js.snap
@@ -1,48 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ui-auth/Password/PasswordEntryConnected should render 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -320,6 +316,6 @@ exports[`ui-auth/Password/PasswordEntryConnected should render 1`] = `
         </View>
       </View>
     </View>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;

--- a/packages/apollos-ui-auth/src/Profile/__snapshots__/ProfileEntry.tests.js.snap
+++ b/packages/apollos-ui-auth/src/Profile/__snapshots__/ProfileEntry.tests.js.snap
@@ -1,48 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ui-auth/Profile/ProfileEntry should render 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -406,6 +402,6 @@ exports[`ui-auth/Profile/ProfileEntry should render 1`] = `
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;

--- a/packages/apollos-ui-auth/src/Profile/__snapshots__/ProfileEntryConnected.tests.js.snap
+++ b/packages/apollos-ui-auth/src/Profile/__snapshots__/ProfileEntryConnected.tests.js.snap
@@ -1,48 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ui-auth/Profile/ProfileEntryConnected should render 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -467,6 +463,6 @@ exports[`ui-auth/Profile/ProfileEntryConnected should render 1`] = `
         </View>
       </View>
     </View>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;

--- a/packages/apollos-ui-auth/src/ProfileDetails/__snapshots__/ProfileDetailsEntry.tests.js.snap
+++ b/packages/apollos-ui-auth/src/ProfileDetails/__snapshots__/ProfileDetailsEntry.tests.js.snap
@@ -1,48 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -405,29 +401,25 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render 1`] = `
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render a different background component 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
-    ]
-  }
->
-  <View>
+<View>
+  <View
+    onLayout={[Function]}
+    style={
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
     <RCTScrollView>
       <View>
         <View
@@ -793,48 +785,44 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render a different backgroun
 `;
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render a loading state 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -1197,53 +1185,49 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render a loading state 1`] =
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render when disabled 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -1606,53 +1590,49 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render when disabled 1`] = `
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render with a different gender list 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -2015,53 +1995,49 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render with a different gend
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render with a different prompt and title 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -2424,53 +2400,49 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render with a different prom
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;
 
 exports[`ui-auth/Profile/ProfileDetailsEntry should render with errors 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -2833,6 +2805,6 @@ exports[`ui-auth/Profile/ProfileDetailsEntry should render with errors 1`] = `
         </View>
       </View>
     </RCTScrollView>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;

--- a/packages/apollos-ui-auth/src/ProfileDetails/__snapshots__/ProfileDetailsEntryConnected.tests.js.snap
+++ b/packages/apollos-ui-auth/src/ProfileDetails/__snapshots__/ProfileDetailsEntryConnected.tests.js.snap
@@ -1,48 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ui-auth/Profile/ProfileDetailsEntryConnected should render 1`] = `
-<View
-  onLayout={[Function]}
-  style={
+<BVLinearGradient
+  colors={
     Array [
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-      Object {
-        "paddingBottom": 0,
-      },
+      4294967295,
+      4294506484,
     ]
   }
+  endPoint={
+    Object {
+      "x": 0.5,
+      "y": 1,
+    }
+  }
+  locations={null}
+  startPoint={
+    Object {
+      "x": 0.5,
+      "y": 0,
+    }
+  }
+  style={
+    Object {
+      "flex": 1,
+      "height": "100%",
+    }
+  }
 >
-  <BVLinearGradient
-    colors={
-      Array [
-        4294967295,
-        4294506484,
-      ]
-    }
-    endPoint={
-      Object {
-        "x": 0.5,
-        "y": 1,
-      }
-    }
-    locations={null}
-    startPoint={
-      Object {
-        "x": 0.5,
-        "y": 0,
-      }
-    }
+  <View
+    onLayout={[Function]}
     style={
-      Object {
-        "flex": 1,
-        "height": "100%",
-      }
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "paddingBottom": 0,
+        },
+      ]
     }
   >
     <RCTScrollView>
@@ -465,6 +461,6 @@ exports[`ui-auth/Profile/ProfileDetailsEntryConnected should render 1`] = `
         </View>
       </View>
     </View>
-  </BVLinearGradient>
-</View>
+  </View>
+</BVLinearGradient>
 `;

--- a/packages/apollos-ui-auth/src/styles.js
+++ b/packages/apollos-ui-auth/src/styles.js
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  Platform,
-  View,
-  KeyboardAvoidingView,
-  StatusBar,
-  ScrollView,
-  StyleSheet,
-} from 'react-native';
+import { Platform, View, KeyboardAvoidingView, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import PropTypes from 'prop-types';
@@ -27,9 +20,14 @@ import {
 } from '@apollosproject/ui-kit';
 
 const FlexedSafeAreaView = styled(
-  { height: '100%' },
+  { flex: 1 },
   'ui-auth.FlexedSafeAreaView'
 )(SafeAreaView);
+
+const FlexedKeyboardAvoidingView = styled(
+  { flex: 1 },
+  'ui-auth.FlexedKeyboardAvoidingView'
+)(KeyboardAvoidingView);
 
 const BrandIcon = withTheme(
   ({ theme }) => ({
@@ -170,15 +168,9 @@ const ProfileEntryFieldContainer = ({
   isLoading,
   children,
 }) => (
-  <KeyboardAvoidingView
-    style={StyleSheet.absoluteFill}
-    behavior={'padding'}
-    keyboardVerticalOffset={
-      Platform.OS === 'android' ? StatusBar.currentHeight : 0
-    }
-  >
-    <BackgroundComponent>
-      <FlexedSafeAreaView>
+  <BackgroundComponent>
+    <FlexedSafeAreaView edges={['right', 'top', 'left']}>
+      <FlexedKeyboardAvoidingView behavior={'padding'}>
         <ScrollView>
           <PaddedView>
             <TitleText>{title}</TitleText>
@@ -199,9 +191,9 @@ const ProfileEntryFieldContainer = ({
             />
           </PaddedView>
         ) : null}
-      </FlexedSafeAreaView>
-    </BackgroundComponent>
-  </KeyboardAvoidingView>
+      </FlexedKeyboardAvoidingView>
+    </FlexedSafeAreaView>
+  </BackgroundComponent>
 );
 
 ProfileEntryFieldContainer.propTypes = {
@@ -220,6 +212,7 @@ ProfileEntryFieldContainer.defaultProps = {
 
 export {
   FlexedSafeAreaView,
+  FlexedKeyboardAvoidingView,
   BrandIcon,
   TitleText,
   PromptText,


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The next/submit button is no longer covered by the keyboard. 
<img width="538" alt="Screen Shot 2021-02-16 at 9 27 15 PM" src="https://user-images.githubusercontent.com/1637694/108148289-8301a980-709e-11eb-847a-cdcaec6f41d8.png">
<img width="538" alt="Screen Shot 2021-02-16 at 9 23 50 PM" src="https://user-images.githubusercontent.com/1637694/108148290-839a4000-709e-11eb-9c01-fb8a7886709f.png">



### How do I test this PR?

Walk through the auth/onboarding flow. Aka - use an email or phone number you haven't used before. 