### PR TITLE
fix: Correctly default date picker to 18 years ago

### DIFF
--- a/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntry.js
+++ b/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntry.js
@@ -36,9 +36,17 @@ const ProfileDetailsEntry = (props) => (
     <DatePicker
       type={'DateInput'}
       placeholder={'Select a date...'}
-      value={moment(
-        get(props.values, 'birthDate', props.defaultDate) || props.defaultDate
-      ).toDate()}
+      value={
+        // If we have either a birthdate or a default date
+        get(props.values, 'birthdate') || props.defaultDate
+          ? // Pass it along to the datepicker
+            moment(
+              get(props.values, 'birthDate', props.defaultDate) ||
+                props.defaultDate
+            ).toDate()
+          : // Otherwise pass null. The datepicker has sane defaults
+            null
+      }
       error={get(props.touched, 'birthDate') && get(props.errors, 'birthDate')}
       displayValue={
         // only show a birthday if we have one.
@@ -81,7 +89,6 @@ ProfileDetailsEntry.defaultProps = {
   prompt:
     'Help us understand who you are so we can connect you with the best ministries and events.',
   genderList: ['Male', 'Female', 'Prefer not to reply'],
-  defaultDate: new Date(),
 };
 
 ProfileDetailsEntry.LegalText = LegalText;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The "max" is 16 years ago. Previously it was trying to set the default to "today', and then snapping back to 16 years. Now, you'll be able to change your month and day before changing your year, while also not being able to select an age less than 16 years old. 

### How do I test this PR?

Visit the age selection in onboarding by using a new email when logging in. 


![2021-02-16 21 52 18](https://user-images.githubusercontent.com/1637694/108150167-3750ff00-70a2-11eb-9cf4-e4ef9214c205.gif)
