### PR TITLE
feat: add new generic content query

### DIFF
--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -561,7 +561,7 @@ export const contentChannelSchema = gql`
     content(channel: CONTENT_CHANNEL_TYPE): ContentItemsConnection
   }
 
-  enum CONTENT_CHANNEL_TYPE {
+  enum CONTENT_CHANNEL {
     Sermons
     Devotionals
     Articles

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -558,6 +558,14 @@ export const contentChannelSchema = gql`
   extend type Query {
     contentChannels: [ContentChannel]
       @deprecated(reason: "No longer supported.")
+    content(channel: CONTENT_CHANNEL_TYPE): ContentItemsConnection
+  }
+
+  enum CONTENT_CHANNEL_TYPE {
+    Sermons
+    Devotionals
+    Articles
+    Events
   }
 `;
 


### PR DESCRIPTION
I've thought about this a lot. What we need for the web (and for 90% of app feeds) is a simple list of content from a specific channel. For the web specifically, we don't want a "feed" because the arrangement on screen is not as simple as horizontal or vertical. And we also will want to decouple the data and UI because the UI will change depending on the media query.

This is a simple, scalable way to get content using the API. The `CONTENT_CHANNEL` enum map can exist in the `config.yml` if it doesn't already. 
