### PR TITLE
chore: run CI on branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+      - next
+  pull_request:
+    branches:
+      - master
+      - next
+      - v1
 
 jobs:
   title:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - next
+      - v1
   pull_request:
     branches:
       - master


### PR DESCRIPTION
We are not getting accurate Codecov reports because tests don't run on master
