### PR TITLE
feat: Add a unique index for origin fields and switch to uuid for ids

### DIFF
--- a/packages/apollos-data-connector-postgres/jest.setup.js
+++ b/packages/apollos-data-connector-postgres/jest.setup.js
@@ -1,5 +1,5 @@
 import { Client } from 'pg';
-import { dbName } from './test-connect';
+import { dbName } from './src/postgres/test-connect';
 
 const JEST_WORKER_COUNT = 2;
 

--- a/packages/apollos-data-connector-postgres/jest.setup.js
+++ b/packages/apollos-data-connector-postgres/jest.setup.js
@@ -1,9 +1,7 @@
 import { Client } from 'pg';
 import { dbName } from './src/postgres/test-connect';
 
-const JEST_WORKER_COUNT = 2;
-
-export default async () => {
+export default async ({ maxWorkers }) => {
   const client = new Client({
     host: 'localhost',
     database: 'postgres',
@@ -18,7 +16,7 @@ export default async () => {
 
   let count = 1;
 
-  while (count <= JEST_WORKER_COUNT) {
+  while (count <= maxWorkers) {
     const name = dbName(count);
 
     try {

--- a/packages/apollos-data-connector-postgres/jest.setup.js
+++ b/packages/apollos-data-connector-postgres/jest.setup.js
@@ -39,7 +39,6 @@ export default async ({ maxWorkers }) => {
         `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
       );
       await dbTestClient.end();
-      console.log(create, uuid, uuid.rows);
     } catch (e) {
       console.error(`Failed to create test database ${name}`);
       console.error(e);

--- a/packages/apollos-data-connector-postgres/jest.setup.js
+++ b/packages/apollos-data-connector-postgres/jest.setup.js
@@ -29,7 +29,17 @@ export default async ({ maxWorkers }) => {
 
     try {
       // eslint-disable-next-line no-await-in-loop
-      await client.query(`CREATE DATABASE ${name};`);
+      const create = await client.query(`CREATE DATABASE ${name};`);
+      const dbTestClient = new Client({
+        host: 'localhost',
+        database: dbName(count),
+      });
+      await dbTestClient.connect();
+      const uuid = await dbTestClient.query(
+        `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
+      );
+      await dbTestClient.end();
+      console.log(create, uuid, uuid.rows);
     } catch (e) {
       console.error(`Failed to create test database ${name}`);
       console.error(e);

--- a/packages/apollos-data-connector-postgres/jest.teardown.js
+++ b/packages/apollos-data-connector-postgres/jest.teardown.js
@@ -1,5 +1,5 @@
 import { Client } from 'pg';
-import { dbName } from './test-connect';
+import { dbName } from './src/postgres/test-connect';
 
 const JEST_WORKER_COUNT = 2;
 

--- a/packages/apollos-data-connector-postgres/jest.teardown.js
+++ b/packages/apollos-data-connector-postgres/jest.teardown.js
@@ -1,9 +1,7 @@
 import { Client } from 'pg';
 import { dbName } from './src/postgres/test-connect';
 
-const JEST_WORKER_COUNT = 2;
-
-export default async () => {
+export default async ({ maxWorkers }) => {
   let count = 1;
 
   const client = new Client({
@@ -13,7 +11,7 @@ export default async () => {
 
   await client.connect();
 
-  while (count <= JEST_WORKER_COUNT) {
+  while (count <= maxWorkers) {
     // eslint-disable-next-line no-await-in-loop
     await client.query(
       `DROP DATABASE IF EXISTS ${dbName(count)} WITH (FORCE);`

--- a/packages/apollos-data-connector-postgres/src/people/__tests__/model.js
+++ b/packages/apollos-data-connector-postgres/src/people/__tests__/model.js
@@ -23,6 +23,8 @@ describe('People model', () => {
 
     expect(me.firstName).toBe('Vincent');
     expect(me.createdAt).toBeInstanceOf(Date);
-    expect(me.id).toBe(1);
+    expect(me.id).toMatch(
+      /[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/i
+    );
   });
 });

--- a/packages/apollos-data-connector-postgres/src/postgres/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/index.js
@@ -5,7 +5,7 @@ import './pgEnum-fix';
 import { Sequelize, DataTypes } from 'sequelize';
 import { createGlobalId } from '@apollosproject/server-core';
 import ApollosConfig from '@apollosproject/config';
-import connectJest from '../../test-connect';
+import connectJest from './test-connect';
 
 const sequelizeConfigOptions =
   process.env.NODE_ENV === 'test' ? { logging: false } : {};

--- a/packages/apollos-data-connector-postgres/src/postgres/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/index.js
@@ -102,8 +102,8 @@ const defineModel = ({
       indexes: [
         { unique: true, fields: ['apollosId'] },
         ...(external
-          ? { unique: true, fields: ['originId', 'originType'] }
-          : {}),
+          ? [{ unique: true, fields: ['originId', 'originType'] }]
+          : []),
         ...(sequelizeOptions?.indexes || []),
       ],
     }

--- a/packages/apollos-data-connector-postgres/src/postgres/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/index.js
@@ -45,6 +45,11 @@ const defineModel = ({
     modelName,
     {
       ...attributes,
+      id: {
+        primaryKey: true,
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+      },
       apollosId: {
         type: DataTypes.STRING,
         allowNull: true, // we set this value with an "afterCreate" hook if not set.
@@ -96,6 +101,9 @@ const defineModel = ({
       },
       indexes: [
         { unique: true, fields: ['apollosId'] },
+        ...(external
+          ? { unique: true, fields: ['originId', 'originType'] }
+          : {}),
         ...(sequelizeOptions?.indexes || []),
       ],
     }

--- a/packages/apollos-data-connector-postgres/src/postgres/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/index.js
@@ -48,7 +48,7 @@ const defineModel = ({
       id: {
         primaryKey: true,
         type: DataTypes.UUID,
-        defaultValue: DataTypes.UUIDV4,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
       },
       apollosId: {
         type: DataTypes.STRING,

--- a/packages/apollos-data-connector-postgres/src/postgres/test-connect.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/test-connect.js
@@ -1,4 +1,4 @@
-import './src/postgres/pgEnum-fix';
+import './pgEnum-fix';
 import { Sequelize } from 'sequelize';
 import ApollosConfig from '@apollosproject/config';
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The unique index on the `originId` and `originType` allows us to do an "upsert" using those two fields. 
The UUID is how we'll be storing IDs moving forward.

### How do I test this PR?
