### PR TITLE
fix: allow theme HOCs to accept custom theme prop

### DIFF
--- a/packages/apollos-ui-connected/src/ContentChildFeedConnected/__snapshots__/ContentChildFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ContentChildFeedConnected/__snapshots__/ContentChildFeedConnected.tests.js.snap
@@ -513,6 +513,7 @@ exports[`the ContentChildFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -714,6 +715,7 @@ exports[`the ContentChildFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -915,6 +917,7 @@ exports[`the ContentChildFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -1116,6 +1119,7 @@ exports[`the ContentChildFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}

--- a/packages/apollos-ui-connected/src/ContentParentFeedConnected/__snapshots__/ContentParentFeed.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ContentParentFeedConnected/__snapshots__/ContentParentFeed.tests.js.snap
@@ -513,6 +513,7 @@ exports[`the ContentParentFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -714,6 +715,7 @@ exports[`the ContentParentFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -915,6 +917,7 @@ exports[`the ContentParentFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -1116,6 +1119,7 @@ exports[`the ContentParentFeedConnected component should render 1`] = `
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}

--- a/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalContentSeriesFeedConnected/__snapshots__/HorizontalContentSeriesFeedConnected.tests.js.snap
@@ -513,6 +513,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -714,6 +715,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -915,6 +917,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}
@@ -1116,6 +1119,7 @@ exports[`the HorizontalContentSeriesFeedConnected component should render 1`] = 
                                 }
                               >
                                 <Image
+                                  customTheme={null}
                                   disabled={false}
                                   fadeDuration={250}
                                   isLoading={false}

--- a/packages/apollos-ui-kit/src/DefaultCard/index.js
+++ b/packages/apollos-ui-kit/src/DefaultCard/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { withTheme } from '../theme';
+import { withTheme, named } from '../theme';
 import styled from '../styled';
 import Card, { CardImage, CardLabel, CardContent } from '../Card';
 import { H3, BodyText } from '../typography';
@@ -141,4 +141,4 @@ DefaultCard.propTypes = {
 
 DefaultCard.displayName = 'DefaultCard';
 
-export default DefaultCard;
+export default named('ui-kit.DefaultCard')(DefaultCard);

--- a/packages/apollos-ui-kit/src/FeaturedCard/index.js
+++ b/packages/apollos-ui-kit/src/FeaturedCard/index.js
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import { withTheme, ThemeMixin } from '../theme';
+import { withTheme, ThemeMixin, named } from '../theme';
 import styled from '../styled';
 import Card, { CardImage, CardLabel, CardContent } from '../Card';
 import FlexedView from '../FlexedView';
@@ -223,4 +223,4 @@ FeaturedCard.defaultProps = {
 
 FeaturedCard.displayName = 'FeaturedCard';
 
-export default FeaturedCard;
+export default named('ui-kit.FeaturedCard')(FeaturedCard);

--- a/packages/apollos-ui-kit/src/HighlightCard/index.js
+++ b/packages/apollos-ui-kit/src/HighlightCard/index.js
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import { withTheme, ThemeMixin } from '../theme';
+import { withTheme, ThemeMixin, named } from '../theme';
 import styled from '../styled';
 import Card, { CardContent, CardLabel, CardImage } from '../Card';
 import FlexedView from '../FlexedView';
@@ -215,4 +215,4 @@ HighlightCard.defaultProps = {
   actionIcon: 'play-opaque',
 };
 
-export default HighlightCard;
+export default named('ui-kit.HighlightCard')(HighlightCard);

--- a/packages/apollos-ui-kit/src/theme/ThemeProvider.js
+++ b/packages/apollos-ui-kit/src/theme/ThemeProvider.js
@@ -12,7 +12,7 @@ export class ThemeProvider extends PureComponent {
   };
 
   static childContextTypes = {
-    theme: PropTypes.shape(THEME_PROPS),
+    themeContext: PropTypes.shape(THEME_PROPS),
     themeInput: PropTypes.shape(THEME_PROPS),
     iconInput: PropTypes.objectOf(PropTypes.func),
   };
@@ -24,7 +24,7 @@ export class ThemeProvider extends PureComponent {
   };
 
   getChildContext = () => ({
-    theme: createTheme(this.props.themeInput),
+    themeContext: createTheme(this.props.themeInput),
     themeInput: this.props.themeInput,
     iconInput: this.props.iconInput,
   });

--- a/packages/apollos-ui-kit/src/theme/mixins.js
+++ b/packages/apollos-ui-kit/src/theme/mixins.js
@@ -33,20 +33,20 @@ const withThemeMixin = (themeInput) =>
   compose(
     mapProps((props) => ({ ownProps: props })),
     getContext({
-      theme: PropTypes.shape(THEME_PROPS),
+      themeContext: PropTypes.shape(THEME_PROPS),
       themeInput: PropTypes.shape(THEME_PROPS),
     }),
     withPropsOnChange(
       (props, nextProps) =>
-        props.theme !== nextProps.theme ||
+        props.themeContext !== nextProps.themeContext ||
         props.themeInput !== nextProps.themeInput ||
         props.ownProps.mixin !== nextProps.ownProps.mixin,
-      ({ theme, themeInput: originalThemeInput, ownProps }) => {
+      ({ themeContext, themeInput: originalThemeInput, ownProps }) => {
         // Start with the original theme input
         let themeInputAsObject = themeInput;
         // If it's a function, call the function with the current props + theme.
         if (typeof themeInput === 'function') {
-          themeInputAsObject = themeInput({ ...ownProps, theme });
+          themeInputAsObject = themeInput({ ...ownProps, theme: themeContext });
         }
         // Now, merge together the input, and strip out all the null leaves.
         // This is important. Null leaves will override default values from the base theme, without providing a replacement.
@@ -61,18 +61,18 @@ const withThemeMixin = (themeInput) =>
         const themeWithMixin = createTheme(themeInputAsObject);
 
         return {
-          theme: themeWithMixin,
+          themeContext: themeWithMixin,
           themeInput: themeInputAsObject,
         };
       }
     ),
     withContext(
       {
-        theme: PropTypes.shape(THEME_PROPS),
+        themeContext: PropTypes.shape(THEME_PROPS),
         themeInput: PropTypes.shape(THEME_PROPS),
       },
-      ({ theme, themeInput: newThemeInput }) => ({
-        theme,
+      ({ themeContext, themeInput: newThemeInput }) => ({
+        themeContext,
         themeInput: newThemeInput,
       })
     ),

--- a/packages/apollos-ui-kit/src/theme/withTheme.js
+++ b/packages/apollos-ui-kit/src/theme/withTheme.js
@@ -11,9 +11,9 @@ export default function withTheme(mapperFn = DEFAULT_MAPPER_FN, fqn) {
   return hoistStatics(
     compose(
       getContext({
-        theme: PropTypes.shape(THEME_PROPS),
+        themeContext: PropTypes.shape(THEME_PROPS),
       }),
-      mapProps(({ theme, ...otherProps }) => {
+      mapProps(({ themeContext: theme, ...otherProps }) => {
         const themeOverridesValue = fqn
           ? get(theme, `overrides['${fqn}']`, {})
           : {};


### PR DESCRIPTION
WOW. That was enlightening.

This will allow us to pass a `theme` prop when using `withTheme` or `withThemeMixin`. I think there's definitely room to overhaul our theming system to remove the vast assortment of HOCs we have available, they mostly do the same thing in a slightly different way.
