### PR TITLE
fix: return empty string with null HTML

### DIFF
--- a/packages/apollos-data-connector-rock/src/__snapshots__/sanitize-html.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/__snapshots__/sanitize-html.tests.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the sanitizeHtml function returns an empty string with null HTML 1`] = `""`;

--- a/packages/apollos-data-connector-rock/src/sanitize-html.js
+++ b/packages/apollos-data-connector-rock/src/sanitize-html.js
@@ -29,9 +29,11 @@ const allowedAttributes = {
 };
 
 // A very picky HTML sanitizer
-export default function (dirty) {
-  return sanitizeHtml(dirty, {
-    allowedTags,
-    allowedAttributes,
-  });
-}
+export default (dirty) =>
+  // by default, it turns null into "null"
+  dirty
+    ? sanitizeHtml(dirty, {
+        allowedTags,
+        allowedAttributes,
+      })
+    : '';

--- a/packages/apollos-data-connector-rock/src/sanitize-html.tests.js
+++ b/packages/apollos-data-connector-rock/src/sanitize-html.tests.js
@@ -1,0 +1,7 @@
+import sanitizeHtml from './sanitize-html';
+
+describe('the sanitizeHtml function', () => {
+  it('returns an empty string with null HTML', () => {
+    expect(sanitizeHtml(null)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
The `sanitize-html` pkg was converting `null` to `"null"`. This will return an empty string instead
