### PR TITLE
feat: Add apollosUser database attribute

### DIFF
--- a/packages/apollos-data-connector-postgres/src/people/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/people/dataSource.js
@@ -26,6 +26,7 @@ export default class Person extends PostgresDataSource {
   async create(attributes) {
     const cleanedAttributes = camelCaseKeys(attributes);
     const person = await this.model.create({
+      apollosUser: true,
       ...cleanedAttributes,
       ...(cleanedAttributes.gender
         ? { gender: cleanedAttributes.gender.toUpperCase() }

--- a/packages/apollos-data-connector-postgres/src/people/model.js
+++ b/packages/apollos-data-connector-postgres/src/people/model.js
@@ -18,6 +18,10 @@ const createModel = defineModel({
     birthDate: DataTypes.DATE,
     profileImageUrl: DataTypes.STRING,
     gender: DataTypes.ENUM(Object.values(Gender)),
+    apollosUser: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
   },
 });
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Keeps track if a user is an apollos users (as opposed to a user shoveled from a CMS) 

### How do I test this PR?
