### PR TITLE
feat: add feature sources to schema

### DIFF
--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -805,6 +805,11 @@ export const featuresSchema = gql`
   interface Feature {
     id: ID!
     order: Int # 0 is the "Main Content". If order is < 0 than this comes before the body content.
+    sources: [FeatureSource]
+  }
+
+  enum FeatureSource {
+    SERIES_IN_PROGRESS
   }
 
   enum ACTION_FEATURE_ACTION {
@@ -844,6 +849,7 @@ export const featuresSchema = gql`
   type ActionListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     subtitle: String
@@ -865,6 +871,7 @@ export const featuresSchema = gql`
   type ActionBarFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     actions: [ActionBarAction]
@@ -875,6 +882,7 @@ export const featuresSchema = gql`
   type HeroListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     subtitle: String
@@ -904,6 +912,7 @@ export const featuresSchema = gql`
   type VerticalCardListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     subtitle: String
@@ -916,6 +925,7 @@ export const featuresSchema = gql`
   type HorizontalCardListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     subtitle: String
@@ -926,6 +936,7 @@ export const featuresSchema = gql`
   type TextFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     body: String
@@ -934,6 +945,7 @@ export const featuresSchema = gql`
   type ScriptureFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     scriptures: [Scripture]
@@ -942,6 +954,7 @@ export const featuresSchema = gql`
   type WebviewFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     title: String
     linkText: String
@@ -996,6 +1009,7 @@ export const commentSchema = gql`
   type CommentListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
 
     comments: [Comment] @cacheControl(maxAge: 0)
   }
@@ -1003,6 +1017,7 @@ export const commentSchema = gql`
   type AddCommentFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
     relatedNode: Node!
 
     addPrompt: String
@@ -1052,6 +1067,7 @@ export const prayerSchema = gql`
   type PrayerListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
     isCard: Boolean
     title: String
     subtitle: String
@@ -1061,6 +1077,7 @@ export const prayerSchema = gql`
   type VerticalPrayerListFeature implements Feature & Node {
     id: ID!
     order: Int
+    sources: [FeatureSource]
     title: String
     subtitle: String
     prayers: [PrayerRequest]


### PR DESCRIPTION
I took a step back in trying to solve the problem of making the front-end look different based on the algorithm type and I think I came up with good way. By simply exposing the algorithms to the front end, we can change how features are rendered without needing to create new feature types. This accomplishes a couple of other things too. Algorithms have always been cryptic and hidden in source code, this exposes them to the GraphQL schema so users can know the different ways features can be rendered simply by using the API. I also renamed the concept from Algorithms to Sources. We can slowly migrate, no need to change everything now. But I feel it's much easier to understand what they actually are and their purpose.
