### PR TITLE
fix: crash when setting user location

### DIFF
--- a/packages/apollos-ui-mapview/src/MapView/index.js
+++ b/packages/apollos-ui-mapview/src/MapView/index.js
@@ -152,10 +152,14 @@ class MapView extends Component {
   }
 
   get sortedCampuses() {
-    const { campuses = [] } = this.props;
+    const { campuses = [], isLoading } = this.props;
     const { currentCampus } = this.state;
     if (!currentCampus) {
       return campuses;
+    }
+
+    if (isLoading && !campuses.length) {
+      return [];
     }
 
     return [


### PR DESCRIPTION

## DESCRIPTION

### What does this PR do, or why is it needed?

![2021-03-05 14 03 35](https://user-images.githubusercontent.com/1637694/110162134-50ed8880-7dbc-11eb-8be5-f552cbaee33e.gif)

Happens because when a user location is added, the `currentCampus` becomes `[]` and current campus stays as the current campus. It's a funky edge case, and checking for loading fixes it. 

### How do I test this PR?

1. Delete and reinstall the app
2. Boot the app and visit the user settings screen
3. Select Location, approve the request for location permission. 
