### PR TITLE
chore: Refactor Comments model to point directly at the postgres people table

### DIFF
--- a/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
@@ -12,11 +12,7 @@ let person2;
 let currentPerson;
 const context = {
   dataSources: {
-    Auth: {
-      getCurrentPerson: () => person1.id,
-    },
     Person: {
-      getFromId: () => person1,
       getCurrentPersonId: () => currentPerson.id,
     },
   },

--- a/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
@@ -1,31 +1,43 @@
 import { createGlobalId } from '@apollosproject/server-core';
 import { range } from 'lodash';
 import { sequelize, sync } from '../../postgres/index';
-import { createModel } from '../model';
+import { createModel, setupModel } from '../model';
+import { createModel as createPersonModel } from '../../people/model';
 import { createModel as createFlagsModel } from '../../user-flags/model';
 import CommentDataSource from '../dataSource';
 import UserFlagDataSource from '../../user-flags/dataSource';
 
+let person1;
+let person2;
+let currentPerson;
 const context = {
   dataSources: {
     Auth: {
-      getCurrentPerson: () => ({ id: 1 }),
+      getCurrentPerson: () => person1.id,
     },
     Person: {
-      getFromId: () => ({ id: 1 }),
+      getFromId: () => person1,
+      getCurrentPersonId: () => currentPerson.id,
     },
   },
 };
 
 describe('Apollos Postgres Comments DatSource', () => {
   beforeEach(async () => {
-    try {
-      await createModel();
-      await createFlagsModel();
-      await sync({ force: true });
-    } catch (e) {
-      console.error(e);
-    }
+    await createModel();
+    await createFlagsModel();
+    await createPersonModel();
+    await setupModel();
+    await sync({ force: true });
+    person1 = await sequelize.models.people.create({
+      originId: '1',
+      originType: 'rock',
+    });
+    person2 = await sequelize.models.people.create({
+      originId: '2',
+      originType: 'rock',
+    });
+    currentPerson = person1;
   });
   afterEach(async () => {
     await sequelize.drop({});
@@ -69,6 +81,7 @@ describe('Apollos Postgres Comments DatSource', () => {
       nodeId: 123,
       nodeType: 'UniversalContentItem',
     });
+
     expect(comments.length).toBe(1);
   });
 
@@ -95,7 +108,7 @@ describe('Apollos Postgres Comments DatSource', () => {
   it('should return only public comments for a given node', async () => {
     const commentDataSource = new CommentDataSource();
     // Change the user id to a different user
-    context.dataSources.Auth.getCurrentPerson = () => ({ id: 2 });
+    currentPerson = person2;
     commentDataSource.initialize({ context });
 
     // eslint-disable-next-line no-restricted-syntax
@@ -108,7 +121,7 @@ describe('Apollos Postgres Comments DatSource', () => {
       });
     }
     // Go back to our original user user
-    context.dataSources.Auth.getCurrentPerson = () => ({ id: 1 });
+    currentPerson = person1;
     const itemComments = await commentDataSource.getForNode({
       nodeId: 123,
       nodeType: 'UniversalContentItem',
@@ -119,7 +132,7 @@ describe('Apollos Postgres Comments DatSource', () => {
   it('should return your private comments', async () => {
     const commentDataSource = new CommentDataSource();
     // Change the user id to a different user
-    context.dataSources.Auth.getCurrentPerson = () => ({ id: 2 });
+    currentPerson = person2;
     commentDataSource.initialize({ context });
 
     // eslint-disable-next-line no-restricted-syntax
@@ -132,7 +145,7 @@ describe('Apollos Postgres Comments DatSource', () => {
       });
     }
     // Go back to our original user user
-    context.dataSources.Auth.getCurrentPerson = () => ({ id: 1 });
+    currentPerson = person1;
     // eslint-disable-next-line no-restricted-syntax
     for (const index of range(5)) {
       // eslint-disable-next-line no-await-in-loop
@@ -160,7 +173,7 @@ describe('Apollos Postgres Comments DatSource', () => {
     });
 
     const commentPerson = await commentDataSource.getPerson(comment);
-    expect(commentPerson).toEqual({ id: 1 });
+    expect(commentPerson.id).toEqual(person1.id);
   });
 
   it('returns all comments when flagLimit is 0', async () => {

--- a/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
@@ -3,7 +3,10 @@ import { range } from 'lodash';
 import { sequelize, sync } from '../../postgres/index';
 import { createModel, setupModel } from '../model';
 import { createModel as createPersonModel } from '../../people/model';
-import { createModel as createFlagsModel } from '../../user-flags/model';
+import {
+  createModel as createFlagsModel,
+  setupModel as setupFlagsModel,
+} from '../../user-flags/model';
 import CommentDataSource from '../dataSource';
 import UserFlagDataSource from '../../user-flags/dataSource';
 
@@ -14,6 +17,7 @@ const context = {
   dataSources: {
     Person: {
       getCurrentPersonId: () => currentPerson.id,
+      getFromId: (id) => ({ id }),
     },
   },
 };
@@ -24,6 +28,7 @@ describe('Apollos Postgres Comments DatSource', () => {
     await createFlagsModel();
     await createPersonModel();
     await setupModel();
+    await setupFlagsModel();
     await sync({ force: true });
     person1 = await sequelize.models.people.create({
       originId: '1',

--- a/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
@@ -164,19 +164,6 @@ describe('Apollos Postgres Comments DatSource', () => {
     expect(itemComments.length).toBe(5);
   });
 
-  it('should return a user for a comment', async () => {
-    const commentDataSource = new CommentDataSource();
-    commentDataSource.initialize({ context });
-
-    const comment = await commentDataSource.addComment({
-      text: `I am a fun comment!`,
-      parentId: createGlobalId(123, 'UniversalContentItem'),
-    });
-
-    const commentPerson = await commentDataSource.getPerson(comment);
-    expect(commentPerson.id).toEqual(person1.id);
-  });
-
   it('returns all comments when flagLimit is 0', async () => {
     const commentDataSource = new CommentDataSource();
     commentDataSource.initialize({ context });

--- a/packages/apollos-data-connector-postgres/src/comments/__tests__/resolver.js
+++ b/packages/apollos-data-connector-postgres/src/comments/__tests__/resolver.js
@@ -11,11 +11,13 @@ import {
   themeSchema,
 } from '@apollosproject/data-schema';
 import * as Comment from '../index';
+import * as Person from '../../people';
 import * as UserFlag from '../../user-flags/index';
 
 const { getSchema, getContext } = createTestHelpers({
   Comment,
   UserFlag,
+  Person,
 });
 
 describe('Apollos Postgres Comment Flags Resolver', () => {

--- a/packages/apollos-data-connector-postgres/src/comments/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/dataSource.js
@@ -7,7 +7,7 @@ class CommentDataSource extends PostgresDataSource {
   modelName = 'comments';
 
   async addComment({ text, parentId, visibility = Visibility.PUBLIC }) {
-    const currentUser = await this.context.dataSources.Auth.getCurrentPerson();
+    const currentPersonId = await this.context.dataSources.Person.getCurrentPersonId();
 
     const { id, __type } = parseGlobalId(parentId);
 
@@ -17,7 +17,7 @@ class CommentDataSource extends PostgresDataSource {
         externalParentId: String(id),
         externalParentType: __type,
         externalParentSource: 'rock',
-        externalPersonId: String(currentUser.id),
+        personId: currentPersonId,
       },
       defaults: {
         visibility,
@@ -34,9 +34,9 @@ class CommentDataSource extends PostgresDataSource {
   }
 
   async getForNode({ nodeId, nodeType, flagLimit = 0 }) {
-    let currentUser;
+    let currentPersonId;
     try {
-      currentUser = await this.context.dataSources.Auth.getCurrentPerson();
+      currentPersonId = await this.context.dataSources.Person.getCurrentPersonId();
     } catch {
       // no user signed in, that's fine.
     }
@@ -46,11 +46,10 @@ class CommentDataSource extends PostgresDataSource {
       externalParentType: nodeType,
       [Op.or]: [
         { visibility: Visibility.PUBLIC }, // Show public journals
-        ...(currentUser
+        ...(currentPersonId
           ? [
               {
-                externalPersonId: String(currentUser.id),
-                externalParentSource: 'rock',
+                personId: currentPersonId,
               },
             ]
           : []), // Or show journals that belong to you.
@@ -71,7 +70,7 @@ class CommentDataSource extends PostgresDataSource {
       where: { id },
     });
 
-    return this.context.dataSources.Person.getFromId(comment.externalPersonId);
+    return this.context.dataSources.Person.getFromId(comment.personId);
   }
 }
 

--- a/packages/apollos-data-connector-postgres/src/comments/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/dataSource.js
@@ -64,14 +64,6 @@ class CommentDataSource extends PostgresDataSource {
 
     return comments;
   }
-
-  async getPerson({ id }) {
-    const comment = await this.sequelize.models.comments.findOne({
-      where: { id },
-    });
-
-    return this.context.dataSources.Person.getFromId(comment.personId);
-  }
 }
 
 export { CommentDataSource as default };

--- a/packages/apollos-data-connector-postgres/src/comments/model.js
+++ b/packages/apollos-data-connector-postgres/src/comments/model.js
@@ -1,5 +1,5 @@
 import { DataTypes } from 'sequelize';
-import { defineModel } from '../postgres';
+import { defineModel, configureModel } from '../postgres';
 
 const Visibility = {
   PUBLIC: 'PUBLIC',
@@ -12,11 +12,10 @@ const createModel = defineModel({
   resolveType: () => 'Comment',
   attributes: {
     text: DataTypes.TEXT,
+    visibility: DataTypes.ENUM(Object.values(Visibility)),
     externalParentId: DataTypes.TEXT,
     externalParentType: DataTypes.TEXT,
     externalParentSource: DataTypes.TEXT,
-    externalPersonId: DataTypes.TEXT,
-    visibility: DataTypes.ENUM(Object.values(Visibility)),
     flagCount: {
       type: DataTypes.INTEGER,
       defaultValue: 0,
@@ -24,4 +23,9 @@ const createModel = defineModel({
   },
 });
 
-export { createModel, Visibility };
+const setupModel = configureModel(({ sequelize }) => {
+  sequelize.models.comments.belongsTo(sequelize.models.people);
+  sequelize.models.people.hasMany(sequelize.models.comments);
+});
+
+export { createModel, Visibility, setupModel };

--- a/packages/apollos-data-connector-postgres/src/comments/resolver.js
+++ b/packages/apollos-data-connector-postgres/src/comments/resolver.js
@@ -8,8 +8,7 @@ const resolvers = {
       UserFlag.flagComment(args),
   },
   Comment: {
-    person: (root, args, { dataSources: { Comment } }) =>
-      Comment.getPerson(root),
+    person: (root, args, { dataSources: { Comment } }) => root.getPerson(),
     id: ({ apollosId }) => apollosId,
   },
   CommentListFeature: {

--- a/packages/apollos-data-connector-postgres/src/comments/resolver.js
+++ b/packages/apollos-data-connector-postgres/src/comments/resolver.js
@@ -8,7 +8,7 @@ const resolvers = {
       UserFlag.flagComment(args),
   },
   Comment: {
-    person: (root, args, { dataSources: { Comment } }) => root.getPerson(),
+    person: (root) => root.getPerson(),
     id: ({ apollosId }) => apollosId,
   },
   CommentListFeature: {

--- a/packages/apollos-data-connector-postgres/src/follows/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/__tests__/dataSource.js
@@ -9,17 +9,14 @@ import {
 import FollowDataSource from '../dataSource';
 import PeopleDataSource from '../../people/dataSource';
 
-let currentPersonId = 1;
+let currentPersonId;
 
 const context = {
   dataSources: {
-    Auth: {
-      getCurrentPerson: () => ({
-        id: currentPersonId,
-      }),
-    },
+    Auth: {},
     Person: {
       whereCurrentPerson: () => ({ id: currentPersonId }),
+      getCurrentPersonId: () => currentPersonId,
     },
   },
 };

--- a/packages/apollos-data-connector-postgres/src/follows/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/dataSource.js
@@ -9,13 +9,24 @@ class Follow extends PostgresDataSource {
   modelName = 'follows';
 
   async getCurrentUserFollowingPerson({ id }) {
-    const { Person } = this.context.dataSources;
     assertUuid(id, 'getCurrentUserFollowingPerson');
 
-    const currentPersonWhere = await Person.whereCurrentPerson();
-    const currentPerson = await this.sequelize.models.people.findOne({
-      where: currentPersonWhere,
+    const { Person } = this.context.dataSources;
+    const currentPersonId = await Person.getCurrentPersonId();
+
+    return this.model.findOne({
+      where: {
+        requestPersonId: currentPersonId,
+        followedPersonId: id,
+      },
     });
+  }
+
+  async getPersonFollowingCurrentUser({ id }) {
+    assertUuid(id, 'getPersonFollowingCurrentUser');
+
+    const { Person } = this.context.dataSources;
+    const currentPersonId = await Person.getCurrentPersonId();
 
     return this.model.findOne({
       where: {
@@ -27,7 +38,8 @@ class Follow extends PostgresDataSource {
 
   // eslint-disable-next-line consistent-return
   async requestFollow({ followedPersonId }) {
-    const currentPersonId = await this.getCurrentPersonId();
+    const { Person } = this.context.dataSources;
+    const currentPersonId = await Person.getCurrentPersonId();
 
     const { id } = parseGlobalId(followedPersonId);
 
@@ -58,7 +70,8 @@ class Follow extends PostgresDataSource {
   }
 
   async acceptFollowRequest({ requestPersonId }) {
-    const currentPersonId = await this.getCurrentPersonId();
+    const { Person } = this.context.dataSources;
+    const currentPersonId = await Person.getCurrentPersonId();
 
     const { id } = parseGlobalId(requestPersonId);
 
@@ -81,7 +94,8 @@ class Follow extends PostgresDataSource {
   }
 
   async ignoreFollowRequest({ requestPersonId }) {
-    const currentPersonId = await this.getCurrentPersonId();
+    const { Person } = this.context.dataSources;
+    const currentPersonId = await Person.getCurrentPersonId();
 
     const { id } = parseGlobalId(requestPersonId);
 
@@ -153,7 +167,8 @@ class Follow extends PostgresDataSource {
   };
 
   async followRequests() {
-    const currentPersonId = await this.getCurrentPersonId();
+    const { Person } = this.context.dataSources;
+    const currentPersonId = await Person.getCurrentPersonId();
 
     const currentPerson = await this.sequelize.models.people.findOne({
       where: {
@@ -165,13 +180,6 @@ class Follow extends PostgresDataSource {
       joinTableAttributes: ['state'],
       through: { where: { state: { [Op.or]: [FollowState.REQUESTED, null] } } },
     });
-  }
-
-  async getCurrentPersonId() {
-    const { Person } = this.context.dataSources;
-    const currentPersonWhere = await Person.whereCurrentPerson();
-    const person = await Person.model.findOne({ where: currentPersonWhere });
-    return person.id;
   }
 }
 

--- a/packages/apollos-data-connector-postgres/src/follows/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/dataSource.js
@@ -36,19 +36,6 @@ class Follow extends PostgresDataSource {
     });
   }
 
-  async getPersonFollowingCurrentUser({ id }) {
-    assertUuid(id, 'getPersonFollowingCurrentUser');
-
-    const currentPersonId = await this.getCurrentPersonId();
-
-    return this.model.findOne({
-      where: {
-        requestPersonId: id,
-        followedPersonId: currentPersonId,
-      },
-    });
-  }
-
   // eslint-disable-next-line consistent-return
   async requestFollow({ followedPersonId }) {
     const { Person } = this.context.dataSources;

--- a/packages/apollos-data-connector-postgres/src/follows/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/dataSource.js
@@ -30,7 +30,7 @@ class Follow extends PostgresDataSource {
 
     return this.model.findOne({
       where: {
-        requestPersonId: currentPerson.id,
+        requestPersonId: currentPersonId,
         followedPersonId: id,
       },
     });

--- a/packages/apollos-data-connector-postgres/src/people/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/people/dataSource.js
@@ -86,4 +86,10 @@ export default class Person extends PostgresDataSource {
 
     return where;
   };
+
+  async getCurrentPersonId() {
+    const currentPersonWhere = await this.whereCurrentPerson();
+    const person = await this.model.findOne({ where: currentPersonWhere });
+    return person.id;
+  }
 }

--- a/packages/apollos-data-connector-postgres/src/user-flags/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/user-flags/__tests__/dataSource.js
@@ -1,19 +1,21 @@
 import { createGlobalId } from '@apollosproject/server-core';
 import { sequelize, sync } from '../../postgres/index';
-import { createModel } from '../model';
-import { createModel as createCommentModel } from '../../comments/model';
+import { createModel, setupModel } from '../model';
+import {
+  createModel as createCommentModel,
+  setupModel as setupCommentModel,
+} from '../../comments/model';
+import { createModel as createPeopleModel } from '../../people/model';
 import CommentDataSource from '../../comments/dataSource';
 import UserFlagDataSource from '../dataSource';
 
-let personId;
-
+let person1;
+let person2;
+let currentPerson;
 const context = {
   dataSources: {
-    Auth: {
-      getCurrentPerson: () => ({ id: personId }),
-    },
     Person: {
-      getFromId: () => ({ id: personId }),
+      getCurrentPersonId: () => currentPerson.id,
     },
   },
 };
@@ -23,11 +25,22 @@ describe('Apollos Postgres Comment Flags DataSource', () => {
   let commentDataSource;
 
   beforeEach(async () => {
-    personId = 1;
-
     await createCommentModel();
+    await createPeopleModel();
     await createModel();
+    await setupModel();
+    await setupCommentModel();
     await sync();
+
+    person1 = await sequelize.models.people.create({
+      originId: '1',
+      originType: 'rock',
+    });
+    person2 = await sequelize.models.people.create({
+      originId: '2',
+      originType: 'rock',
+    });
+    currentPerson = person1;
 
     commentDataSource = new CommentDataSource();
     commentDataSource.initialize({ context });
@@ -93,7 +106,7 @@ describe('Apollos Postgres Comment Flags DataSource', () => {
     expect(updatedComments[0].flagCount).toBe(1);
 
     // Have another user flag it though...
-    personId = 2;
+    currentPerson = person2;
     await userFlagDataSource.flagComment({
       commentId: comment.apollosId,
     });
@@ -119,7 +132,7 @@ describe('Apollos Postgres Comment Flags DataSource', () => {
       nodeId: flaggedComment.apollosId,
     });
 
-    const flagPerson = await userFlagDataSource.getPerson(flag);
-    expect(flagPerson).toEqual({ id: personId });
+    const flagPerson = await sequelize.models.people.findByPk(flag.personId);
+    expect(flagPerson.id).toEqual(currentPerson.id);
   });
 });

--- a/packages/apollos-data-connector-postgres/src/user-flags/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/user-flags/dataSource.js
@@ -5,7 +5,7 @@ class UserFlagDataSource extends PostgresDataSource {
   modelName = 'user_flags';
 
   async flagComment({ commentId }) {
-    const currentUser = await this.context.dataSources.Auth.getCurrentPerson();
+    const currentPersonId = await this.context.dataSources.Person.getCurrentPersonId();
 
     const { id, __type } = parseGlobalId(commentId);
 
@@ -14,7 +14,7 @@ class UserFlagDataSource extends PostgresDataSource {
       where: {
         nodeId: String(id),
         nodeType: __type,
-        externalPersonId: String(currentUser.id),
+        personId: currentPersonId,
       },
     });
 
@@ -29,14 +29,6 @@ class UserFlagDataSource extends PostgresDataSource {
     });
 
     return comment;
-  }
-
-  async getPerson({ id }) {
-    const flag = await this.sequelize.models.user_flags.findOne({
-      where: { id },
-    });
-
-    return this.context.dataSources.Person.getFromId(flag.externalPersonId);
   }
 }
 

--- a/packages/apollos-data-connector-postgres/src/user-flags/model.js
+++ b/packages/apollos-data-connector-postgres/src/user-flags/model.js
@@ -1,5 +1,5 @@
 import { DataTypes } from 'sequelize';
-import { defineModel } from '../postgres';
+import { defineModel, configureModel } from '../postgres';
 
 const createModel = defineModel({
   modelName: 'user_flags',
@@ -7,9 +7,12 @@ const createModel = defineModel({
   attributes: {
     nodeId: DataTypes.TEXT,
     nodeType: DataTypes.TEXT,
-    externalPersonId: DataTypes.TEXT,
   },
 });
 
+const setupModel = configureModel(({ sequelize }) => {
+  sequelize.models.user_flags.belongsTo(sequelize.models.people);
+  sequelize.models.people.hasMany(sequelize.models.user_flags);
+});
 // eslint-disable-next-line import/prefer-default-export
-export { createModel };
+export { createModel, setupModel };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Gets rid of the "external user id" notion, and uses the postgres primitives for a table join. One of those things that we couldn't easily do if we were in production, but thankfully we're technically not :) 

Here's my set of test mutations, but you can also test by clicking around and adding comments in the app. No change in actual functionality. 
```
query content {
  contentChannels {
    childContentItemsConnection {
      edges {
        node {
          id
          ... on FeaturesNode {
            featureFeed {
              features {
                ... on CommentListFeature {
                  id
                }
              }
            }
          }
        }
      }
    }
  }
}

query commentListFeature {
  node(id:"CommentListFeature:f5f25daa33b6f865b2f0d38f199b8de9dbaac83c6efefefeb49da137258038333a3794da043a4ca891c2f3ff182f33ca9dc2869613cc5bae845ecbe13347e517"){
    id
    ... on CommentListFeature {
      id
      comments {
        id
        person {
          firstName
          lastName
        }
        text
      }
    }
  }
}

mutation addComment {
	addComment(parentId:"WeekendContentItem:f8460101368b38c5aa9bbea8b2b8a625", text:"testing this stuff out :) today", visibility:PUBLIC){
    id
  }  
}


mutation flagComment {
  flagComment(commentId:"Comment:46af1b5bbd9b1a1e0a174ec3d955e91f902221e3705c6926055872475ec7ff796d7b52d5be6cfea5bc7f785800a9fa96"){
id}
}
```

### How do I test this PR?
