### PR TITLE
chore: Use Postgres uuids wherever possible

### DIFF
--- a/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/comments/__tests__/dataSource.js
@@ -42,7 +42,7 @@ describe('Apollos Postgres Comments DatSource', () => {
     });
 
     expect(comment.text).toBe('I am a fun comment!');
-    expect(comment.apollosId).toBe(createGlobalId(comment.id, 'Comment'));
+    expect(comment.apollosId).toBe(`Comment:${comment.id}`);
   });
 
   it('should prevent creating duplicate comments', async () => {
@@ -180,7 +180,7 @@ describe('Apollos Postgres Comments DatSource', () => {
     });
 
     await flagDataSource.flagComment({
-      commentId: createGlobalId(comment.id, 'Comment'),
+      commentId: `Comment:${comment.id}`,
     });
 
     const itemComments = await commentDataSource.getForNode({
@@ -207,7 +207,7 @@ describe('Apollos Postgres Comments DatSource', () => {
     });
 
     await flagDataSource.flagComment({
-      commentId: createGlobalId(comment.id, 'Comment'),
+      commentId: `Comment:${comment.id}`,
     });
 
     const itemComments = await commentDataSource.getForNode({

--- a/packages/apollos-data-connector-postgres/src/postgres/__tests__/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/__tests__/index.js
@@ -1,5 +1,4 @@
 import { DataTypes } from 'sequelize';
-import { createGlobalId } from '@apollosproject/server-core';
 import { sequelize, defineModel, configureModel, sync } from '../index';
 
 describe('Apollos Postgres support', () => {
@@ -25,9 +24,7 @@ describe('Apollos Postgres support', () => {
 
     expect(fakeContentItem.title).toBe('A content item title');
     expect(fakeContentItem.apollosType).toBe('ContentItem');
-    expect(fakeContentItem.apollosId).toBe(
-      createGlobalId(fakeContentItem.id, 'ContentItem')
-    );
+    expect(fakeContentItem.apollosId).toBe(`ContentItem:${fakeContentItem.id}`);
   });
   it('should support defining new external models', async () => {
     const makeContentItem = defineModel({

--- a/packages/apollos-data-connector-postgres/src/postgres/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/index.js
@@ -4,7 +4,6 @@
 import './pgEnum-fix';
 import { Sequelize, DataTypes } from 'sequelize';
 import { Client } from 'pg';
-import { createGlobalId } from '@apollosproject/server-core';
 import ApollosConfig from '@apollosproject/config';
 import connectJest from './test-connect';
 import { ensureLocalDb } from './local-db';
@@ -137,28 +136,13 @@ const defineModel = ({
       hooks: {
         ...(sequelizeOptions?.hooks || {}),
         beforeValidate: (instance) => {
-          // First, compoute the apollos type from the resolve type, if passed.
           if (resolveType && !instance.apollosType) {
             instance.apollosType = resolveType(instance);
-          }
-          // Second, use the origin id to compute the apollos id (if it exists)
-          if (
-            instance.originId != null &&
-            instance.apollosType != null &&
-            !instance.apollosId
-          ) {
-            instance.apollosId = createGlobalId(
-              instance.originId,
-              instance.apollosType
-            );
           }
         },
         afterCreate: async (instance, options) => {
           if (!instance.apollosId) {
-            instance.apollosId = createGlobalId(
-              instance.id,
-              instance.apollosType
-            );
+            instance.apollosId = `${instance.apollosType}:${instance.id}`;
             await instance.save({
               transaction: options.transaction,
             });

--- a/packages/apollos-data-connector-postgres/src/user-flags/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/user-flags/__tests__/dataSource.js
@@ -51,9 +51,7 @@ describe('Apollos Postgres Comment Flags DataSource', () => {
     });
 
     expect(flaggedComment.id.toString()).toBe(comment.id.toString());
-    expect(flaggedComment.apollosId).toBe(
-      createGlobalId(comment.id, 'Comment')
-    );
+    expect(flaggedComment.apollosId).toBe(`Comment:${comment.id}`);
   });
 
   it('should increment flag count on comment', async () => {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

We opted to make the apollos ids `${typename}:{database_uuid}`. The shovel does this by default, but your API still was using a different strategy. 

### How do I test this PR?

Easiest way to test is add some comments and check their ID. 

```
mutation addComment {
	addComment(parentId:"WeekendContentItem:f8460101368b38c5aa9bbea8b2b8a625", text:"testing this stuff out :) today 2", visibility:PUBLIC){
    id
  }  
}
```
