### PR TITLE
fix: Upgrades and fixes for comments

### DIFF
--- a/packages/apollos-data-connector-postgres/src/people/resolver.js
+++ b/packages/apollos-data-connector-postgres/src/people/resolver.js
@@ -1,6 +1,4 @@
 import moment from 'moment-timezone';
-// import { createGlobalId } from '@apollosproject/server-core';
-// import ApollosConfig from '@apollosproject/config';
 import { enforceCurrentUser } from '../utils';
 
 export default {
@@ -20,6 +18,7 @@ export default {
       birthDate ? moment(birthDate).toJSON() : null
     ),
     email: enforceCurrentUser(({ email }) => email),
+    nickName: ({ firstName, lastName }) => `${firstName} ${lastName}`,
   },
   Query: {
     suggestedFollows: async (root, args, { dataSources: { Follow } }) =>

--- a/packages/apollos-ui-connected/src/AddCommentFeatureConnected/AddCommentFeatureConnected.js
+++ b/packages/apollos-ui-connected/src/AddCommentFeatureConnected/AddCommentFeatureConnected.js
@@ -86,11 +86,12 @@ const AddCommentFeatureConnected = ({
       {...node}
       {...props}
       loading={isLoading || loading}
-      onSubmit={(text) =>
+      onSubmit={(text, visibility) =>
         addComment({
           variables: {
             text,
             parentId: node.relatedNode.id,
+            visibility,
           },
         })
       }

--- a/packages/apollos-ui-connected/src/AddCommentFeatureConnected/__snapshots__/AddCommentFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/AddCommentFeatureConnected/__snapshots__/AddCommentFeatureConnected.tests.js.snap
@@ -831,7 +831,7 @@ exports[`The CommentListFeatureConnected component should render 1`] = `
                       }
                       thumbTintColor="#FFFFFF"
                       tintColor="#A5A5A5"
-                      value={true}
+                      value={false}
                     />
                   </View>
                 </View>

--- a/packages/apollos-ui-connected/src/AddCommentFeatureConnected/addComment.js
+++ b/packages/apollos-ui-connected/src/AddCommentFeatureConnected/addComment.js
@@ -1,8 +1,12 @@
 import { gql } from '@apollo/client';
 
 export default gql`
-  mutation addComment($text: String!, $parentId: ID!) {
-    addComment(text: $text, parentId: $parentId) {
+  mutation addComment(
+    $text: String!
+    $parentId: ID!
+    $visibility: CommentVisibility
+  ) {
+    addComment(text: $text, parentId: $parentId, visibility: $visibility) {
       id
       text
       person {

--- a/packages/apollos-ui-connected/src/CommentListFeatureConnected/CommentListFeatureConnected.js
+++ b/packages/apollos-ui-connected/src/CommentListFeatureConnected/CommentListFeatureConnected.js
@@ -50,7 +50,37 @@ function CommentListFeatureConnected({
     fetchPolicy: 'cache-and-network',
   });
 
-  const [flagComment] = useMutation(FLAG_COMMENT);
+  const onFlagComment = (cache, { data: { flagComment } }) => {
+    // Let's get started! No crashing allowed.
+    try {
+      // Let's find our comment list.
+      const commentListFeature = cache.readQuery({
+        query: GET_COMMENT_LIST_FEATURE,
+        variables: { featureId },
+      });
+
+      // Now let's remove our flagged comment from that comment list.
+      cache.writeQuery({
+        query: GET_COMMENT_LIST_FEATURE,
+        variables: { featureId },
+        data: {
+          ...commentListFeature,
+          node: {
+            ...commentListFeature.node,
+            comments: commentListFeature.node.comments.filter(
+              ({ id }) => id !== flagComment.id
+            ),
+          },
+        },
+      });
+    } catch (e) {
+      console.warn('Failed to update cache after adding comment', e);
+    }
+  };
+
+  const [flagComment] = useMutation(FLAG_COMMENT, {
+    update: onFlagComment,
+  });
 
   const handlePressActionMenu = ({ id: commentId }) => {
     presentActionOption({

--- a/packages/apollos-ui-kit/src/AddCommentInput/AddCommentInput.js
+++ b/packages/apollos-ui-kit/src/AddCommentInput/AddCommentInput.js
@@ -137,7 +137,7 @@ const AddCommentInput = ({ initialPrompt, addPrompt, onSubmit, profile }) => {
   const [isWriting, setIsWriting] = useState(false);
   const [currentText, setCurrentText] = useState(null);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
-  const [share, setShare] = useState(true);
+  const [share, setShare] = useState('PRIVATE');
 
   const onPressSave = async () => {
     onSubmit && (await onSubmit(currentText, share)); // eslint-disable-line no-unused-expressions
@@ -195,7 +195,10 @@ const AddCommentInput = ({ initialPrompt, addPrompt, onSubmit, profile }) => {
                 Your name and photo will be visible to the community.
               </ShareDisclaimer>
             </ShareText>
-            <Switch value={share} onValueChange={(value) => setShare(value)} />
+            <Switch
+              value={share === 'PUBLIC'}
+              onValueChange={(value) => setShare(value ? 'PUBLIC' : 'PRIVATE')}
+            />
           </Share>
         </ModalContent>
       </Modal>

--- a/packages/apollos-ui-kit/src/AddCommentInput/__snapshots__/AddCommentInput.tests.js.snap
+++ b/packages/apollos-ui-kit/src/AddCommentInput/__snapshots__/AddCommentInput.tests.js.snap
@@ -651,7 +651,7 @@ exports[`The AddCommentInput Component must render 1`] = `
                       }
                       thumbTintColor="#FFFFFF"
                       tintColor="#A5A5A5"
-                      value={true}
+                      value={false}
                     />
                   </View>
                 </View>
@@ -1496,7 +1496,7 @@ exports[`The AddCommentInput Component must render without an avatar 1`] = `
                       }
                       thumbTintColor="#FFFFFF"
                       tintColor="#A5A5A5"
-                      value={true}
+                      value={false}
                     />
                   </View>
                 </View>


### PR DESCRIPTION
## DESCRIPTION

- The private/public flag on the create comment screen now actually does something
- the names of commenters are now showing up again, we had to reimplement the `nickName` field on the postgres person datasource
- Flagging a comment now immediately removes it from the comment list. It might show up again if the server is set to allow for more than one flags, but that's okay for now.
