### PR TITLE
chore: Add GIN name index to optimize searching by name

### DIFF
--- a/packages/apollos-data-connector-postgres/src/people/migrations/003_add_names_index.js
+++ b/packages/apollos-data-connector-postgres/src/people/migrations/003_add_names_index.js
@@ -4,8 +4,11 @@ async function up({ context: queryInterface }) {
   );
 }
 
-async function down() {
-  // no
+async function down({ context: queryInterface }) {
+  await queryInterface.sequelize.removeIndex(
+    'people',
+    'in_people_firstName_and_lastName'
+  );
 }
 
 const name = '003-add-name-index';

--- a/packages/apollos-data-connector-postgres/src/people/migrations/003_add_names_index.js
+++ b/packages/apollos-data-connector-postgres/src/people/migrations/003_add_names_index.js
@@ -1,7 +1,15 @@
+import Sequelize from 'sequelize';
+
 async function up({ context: queryInterface }) {
-  await queryInterface.sequelize.query(
-    `CREATE index in_people_firstName_and_lastName ON people USING gin (lower("firstName" || ' ' || "lastName") gin_trgm_ops)`
-  );
+  await queryInterface.addIndex('people', {
+    name: 'in_people_firstName_and_lastName',
+    using: 'gin',
+    fields: [
+      Sequelize.literal(
+        'lower("firstName" || \' \' || "lastName") gin_trgm_ops'
+      ),
+    ],
+  });
 }
 
 async function down({ context: queryInterface }) {

--- a/packages/apollos-data-connector-postgres/src/people/migrations/003_add_names_index.js
+++ b/packages/apollos-data-connector-postgres/src/people/migrations/003_add_names_index.js
@@ -1,0 +1,13 @@
+async function up({ context: queryInterface }) {
+  await queryInterface.sequelize.query(
+    `CREATE index in_people_firstName_and_lastName ON people USING gin (lower("firstName" || ' ' || "lastName") gin_trgm_ops)`
+  );
+}
+
+async function down() {
+  // no
+}
+
+const name = '003-add-name-index';
+
+module.exports = { up, down, name, order: 4 };

--- a/packages/apollos-data-connector-postgres/src/people/migrations/index.js
+++ b/packages/apollos-data-connector-postgres/src/people/migrations/index.js
@@ -1,6 +1,11 @@
 import CreatePeople001 from './001_create_people';
 import ChangeProfileImageType002 from './002_change_profile_image_url_to_text';
+import AddNamesIndex003 from './003_add_names_index';
 
-const migrations = [CreatePeople001, ChangeProfileImageType002];
+const migrations = [
+  CreatePeople001,
+  ChangeProfileImageType002,
+  AddNamesIndex003,
+];
 
 export default migrations;

--- a/packages/apollos-data-connector-postgres/src/postgres/migrations/001_add_pg_trgm_extension.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/migrations/001_add_pg_trgm_extension.js
@@ -1,0 +1,13 @@
+async function up({ context: queryInterface }) {
+  await queryInterface.sequelize.query(
+    'CREATE EXTENSION IF NOT EXISTS "pg_trgm";'
+  );
+}
+
+async function down() {
+  // no
+}
+
+const name = '001-add-pg_trgm-extension';
+
+module.exports = { up, down, name, order: 0 };

--- a/packages/apollos-data-connector-postgres/src/postgres/migrations/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/migrations/index.js
@@ -1,0 +1,6 @@
+import AddUUID from './000_add_uuid_extension';
+import AddPGTRGM from './001_add_pg_trgm_extension';
+
+const migrations = [AddUUID, AddPGTRGM];
+
+export default migrations;

--- a/packages/apollos-data-connector-postgres/src/postgres/performMigrations.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/performMigrations.js
@@ -1,11 +1,10 @@
 import { flatten } from 'lodash';
 import { Umzug, SequelizeStorage } from 'umzug';
-import AddUuidExtension000 from './migrations/000_add_uuid_extension';
+import systemMigrations from './migrations';
 import { sequelize } from './index';
 
 const createMigrationRunner = async ({ migrations }) => {
-  const migrationsToRun = flatten(migrations);
-  migrationsToRun.unshift(AddUuidExtension000);
+  const migrationsToRun = flatten([...systemMigrations, ...migrations]);
 
   migrationsToRun.sort((a, b) => (a.order < b.order ? -1 : 1));
 


### PR DESCRIPTION
## DESCRIPTION
Speed up searching by full name in the people table.

### What does this PR do, or why is it needed?
This adds an index on `lower("firstName" || ' ' || "lastName")` to allow efficiently searching via full name like "Jimmy Hogoboom". Note that the input search term will need to be made lowercase ("jimmy hogoboom").

### How do I test this PR?
Try running `EXPLAIN ANALYZE SELECT "firstName" || ' ' || "lastName" FROM people WHERE lower("firstName" || ' ' || "lastName") LIKE '%vincent wilson%'` before and after applying this PR to see the speed difference. 
