### PR TITLE
feat: Push notifications on follow request

### DIFF
--- a/packages/apollos-data-connector-onesignal/src/data-source.js
+++ b/packages/apollos-data-connector-onesignal/src/data-source.js
@@ -22,6 +22,7 @@ export default class OneSignal extends RESTDataSource {
     content = '',
     heading,
     subtitle,
+    ...args
   }) {
     return this.post('notifications', {
       app_id: ONE_SIGNAL.APP_ID,
@@ -29,6 +30,7 @@ export default class OneSignal extends RESTDataSource {
       contents: { en: content },
       headings: { en: heading },
       subtitle: { en: subtitle },
+      ...args,
     });
   }
 

--- a/packages/apollos-data-connector-postgres/src/follows/__tests__/__snapshots__/dataSource.js.snap
+++ b/packages/apollos-data-connector-postgres/src/follows/__tests__/__snapshots__/dataSource.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Apollos Postgres FollowRequest DataSource should send a push when creating new follow request 1`] = `
+Object {
+  "requestPersonId": "Person:50a1423a-dfa3-4905-bce6-53d6ed7f5f47",
+}
+`;
+
+exports[`Apollos Postgres FollowRequest DataSource should send a push when creating new follow request 2`] = `
+Array [
+  Object {
+    "id": "acceptFollowRequest",
+    "text": "Confirm",
+  },
+]
+`;
+
+exports[`Apollos Postgres FollowRequest DataSource should send a push when creating new follow request 3`] = `"Jim Randy has asked to follow you."`;
+
 exports[`Apollos Postgres FollowRequest DataSource should throw an error when passing a non-uuid to getStaticSuggestedFollowsFor 1`] = `[Error: ID 1 is not a valid UUID. You are probably passing a Rock (or other) id to getStaticSuggestedFollowsFor when it expects a Postgres UUID.]`;
 
 exports[`Apollos Postgres FollowRequest DataSource should throw an error when passing a non-uuid to getStaticSuggestedFollowsFor 2`] = `[Error: ID 1 is not a valid UUID. You are probably passing a Rock (or other) id to getStaticSuggestedFollowsFor when it expects a Postgres UUID.]`;

--- a/packages/apollos-data-connector-postgres/src/follows/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/__tests__/dataSource.js
@@ -10,6 +10,7 @@ import FollowDataSource from '../dataSource';
 import PeopleDataSource from '../../people/dataSource';
 
 let currentPersonId;
+const notificationMock = jest.fn();
 
 const context = {
   dataSources: {
@@ -17,6 +18,9 @@ const context = {
     Person: {
       whereCurrentPerson: () => ({ id: currentPersonId }),
       getCurrentPersonId: () => currentPersonId,
+    },
+    OneSignal: {
+      createNotification: notificationMock,
     },
   },
 };
@@ -41,8 +45,11 @@ describe('Apollos Postgres FollowRequest DataSource', () => {
     // frustrating that we have to do this, but it's easier to inject a fix here
     // then mock out the whole Person dataSource in the context.
     context.dataSources.Person.model = peopleDataSource.model;
+    context.dataSources.Person.getFromId = peopleDataSource.getFromId;
     person1 = await sequelize.models.people.create({
       originId: '11',
+      firstName: 'Jim',
+      lastName: 'Randy',
       originType: 'rock',
     });
     person2 = await sequelize.models.people.create({
@@ -62,6 +69,7 @@ describe('Apollos Postgres FollowRequest DataSource', () => {
   afterEach(async () => {
     await sequelize.drop({});
     currentPersonId = 1;
+    notificationMock.mockReset();
   });
 
   it('should create new follow request', async () => {
@@ -81,6 +89,21 @@ describe('Apollos Postgres FollowRequest DataSource', () => {
 
     expect(follows.length).toBe(1);
     expect(follows[0].state).toBe(FollowState.REQUESTED);
+    expect(notificationMock.mock.calls.length).toBe(1);
+  });
+
+  it('should send a push when creating new follow request', async () => {
+    const followDataSource = new FollowDataSource();
+
+    followDataSource.initialize({ context });
+
+    await followDataSource.requestFollow({
+      followedPersonId: `Person:${person2.id}`,
+    });
+    expect(notificationMock.mock.calls[0][0].data).toMatchSnapshot();
+    expect(notificationMock.mock.calls[0][0].buttons).toMatchSnapshot();
+    expect(notificationMock.mock.calls[0][0].content).toMatchSnapshot();
+    expect(notificationMock.mock.calls[0][0].to.id).toBe(person2.id);
   });
 
   it('should ignore existing unaccepted request', async () => {
@@ -208,6 +231,7 @@ describe('Apollos Postgres FollowRequest DataSource', () => {
 
     expect(follows.length).toBe(1);
     expect(follows[0].state).toBe(FollowState.ACCEPTED);
+    expect(notificationMock.mock.calls.length).toBe(1);
   });
 
   it('should reset existing denied request', async () => {

--- a/packages/apollos-data-connector-postgres/src/follows/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/dataSource.js
@@ -86,9 +86,10 @@ class Follow extends PostgresDataSource {
     return this.context.dataSources.OneSignal.createNotification({
       content: `${requestPerson.firstName} ${requestPerson.lastName} has asked to follow you.`,
       to: followedPerson,
+      data: { requestPersonId: requestPerson.apollosId },
       buttons: [
         {
-          id: `acceptFollowRequest:${requestPerson.apollosId}`,
+          id: `acceptFollowRequest`,
           text: 'Confirm',
         },
       ],

--- a/packages/apollos-data-connector-postgres/src/follows/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/dataSource.js
@@ -59,13 +59,39 @@ class Follow extends PostgresDataSource {
       }
 
       // If a request already exists that was denied, update it as a new request.
+      this.sendRequestFollowNotification({
+        followedPersonId: id,
+        requestPersonId: currentPersonId,
+      });
       return existingFollow.update({ state: FollowState.REQUESTED });
     }
     // There was no existing request, so lets make one.
+    this.sendRequestFollowNotification({
+      followedPersonId: id,
+      requestPersonId: currentPersonId,
+    });
     return this.model.create({
       requestPersonId: currentPersonId,
       followedPersonId: id,
       state: FollowState.REQUESTED,
+    });
+  }
+
+  async sendRequestFollowNotification({ followedPersonId, requestPersonId }) {
+    const { Person } = this.context.dataSources;
+
+    const followedPerson = await Person.getFromId(followedPersonId);
+    const requestPerson = await Person.getFromId(requestPersonId);
+
+    return this.context.dataSources.OneSignal.createNotification({
+      content: `${requestPerson.firstName} ${requestPerson.lastName} has asked to follow you.`,
+      to: followedPerson,
+      buttons: [
+        {
+          id: `acceptFollowRequest:${requestPerson.apollosId}`,
+          text: 'Confirm',
+        },
+      ],
     });
   }
 

--- a/packages/apollos-ui-connected/src/index.js
+++ b/packages/apollos-ui-connected/src/index.js
@@ -34,6 +34,8 @@ export FeaturesFeedConnected, {
 } from './FeaturesFeedConnected';
 export FollowListConnected, {
   REQUEST_FOLLOW,
+  ACCEPT_FOLLOW_REQUEST,
+  IGNORE_FOLLOW_REQUEST,
   SuggestedFollowListConnected,
   RequestedFollowListConnected,
   GET_SUGGESTED_FOLLOWS,

--- a/packages/apollos-ui-notifications/src/Provider.js
+++ b/packages/apollos-ui-notifications/src/Provider.js
@@ -92,7 +92,6 @@ class NotificationsInit extends Component {
   };
 
   onOpened = (openResult) => {
-    console.log(openResult);
     console.log('Message: ', openResult.notification.payload.body);
     console.log('Data: ', openResult.notification.payload.additionalData);
     console.log('isActive: ', openResult.notification.isAppInFocus);

--- a/packages/apollos-ui-notifications/src/Provider.js
+++ b/packages/apollos-ui-notifications/src/Provider.js
@@ -101,15 +101,15 @@ class NotificationsInit extends Component {
     // apolloschurchapp://SomethingElse/Connect
     // apolloschurchapp://SomethingElse/ContentSingle?itemId=SomeItemId:blablalba
     const url = get(openResult, 'notification.payload.additionalData.url');
-    if (url) {
-      this.navigate(url);
-    } else if (
+    if (
       openResult?.action?.actionID &&
       this.props.actionMap[openResult.action.actionID]
     ) {
       this.props.actionMap[openResult.action.actionID](
         openResult.notification.payload.additionalData
       );
+    } else if (url) {
+      this.navigate(url);
     }
   };
 

--- a/packages/apollos-ui-notifications/src/Provider.js
+++ b/packages/apollos-ui-notifications/src/Provider.js
@@ -36,6 +36,11 @@ class NotificationsInit extends Component {
       writeQuery: PropTypes.func,
       onClearStore: PropTypes.func,
     }).isRequired,
+    actionMap: PropTypes.shape({}),
+  };
+
+  static defaultProps = {
+    actionMap: {},
   };
 
   static navigationOptions = {};
@@ -87,6 +92,7 @@ class NotificationsInit extends Component {
   };
 
   onOpened = (openResult) => {
+    console.log(openResult);
     console.log('Message: ', openResult.notification.payload.body);
     console.log('Data: ', openResult.notification.payload.additionalData);
     console.log('isActive: ', openResult.notification.isAppInFocus);
@@ -98,6 +104,13 @@ class NotificationsInit extends Component {
     const url = get(openResult, 'notification.payload.additionalData.url');
     if (url) {
       this.navigate(url);
+    } else if (
+      openResult?.action?.actionID &&
+      this.props.actionMap[openResult.action.actionID]
+    ) {
+      this.props.actionMap[openResult.action.actionID](
+        openResult.notification.payload.additionalData
+      );
     }
   };
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

![2021-03-18 17 04 21](https://user-images.githubusercontent.com/1637694/111697769-59a67b80-880c-11eb-81b1-37c076f34d41.gif)

Companion PR here: https://github.com/ApollosProject/apollos-templates/pull/296

This is a fun one ... 

Adds in a check for the `actions` that OneSignal sends over, and then lets users provide a custom function to fire when an action matches a passed prop. You can see that being used here: 
https://github.com/ApollosProject/apollos-templates/pull/296/files#diff-9b1509d1d4517465bef7cbb0733f3cf179f1e9b555e50041214d2103218846e6R21-R28

Also adds a call to onesignal to send a notification when a user requests to follow another user. That part is straightforward.


### How do I test this PR?

This is what I did.

1. Clone this PR and it's companion. you need to have a database_url and run postgres.
2. Triple check your env variables. You should have an OneSignal api key and id in your api, and a matching one signal id in your client. 
3. Boot android locally. Check in onesignal that your device showed up. If it doesn't, double check the names of your API keys. 
4. Using graphql, send a follow request to whoever is logged into your android sim. You'll have to use the postgres server to find your apollos id. 
5. Accept that follow request in the sim! 

Note! If you view the notification and then dismiss it, or pull down poorly on the top bar and half view the notification, the button goes away. It's part of the android ui, and it's less of a problem on a real device where it's easy to pull the top bar up and down. 
