### PR TITLE
fix: Avatar not showing up / crash when adding comment

### DIFF
--- a/packages/apollos-ui-fragments/src/features.js
+++ b/packages/apollos-ui-fragments/src/features.js
@@ -240,7 +240,6 @@ const ADD_COMMENT_FEATURE_FRAGMENT = gql`
 
     addPrompt
     initialPrompt
-    isLiked
 
     relatedNode {
       id


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This fragment type was erroring out, was fetching a property that doesn't exist. `AddCommentInput` was still showing up because it's fetches properly w/ the feed view. 

![image](https://user-images.githubusercontent.com/1637694/112859958-5d929300-9081-11eb-94d1-dab2b7bec921.png)


### How do I test this PR?
