### PR TITLE
fix: Restore optimistic updating for add comment

### DIFF
--- a/packages/apollos-ui-connected/src/AddCommentFeatureConnected/addComment.js
+++ b/packages/apollos-ui-connected/src/AddCommentFeatureConnected/addComment.js
@@ -9,6 +9,7 @@ export default gql`
     addComment(text: $text, parentId: $parentId, visibility: $visibility) {
       id
       text
+      isLiked
       person {
         id
         nickName


### PR DESCRIPTION
## DESCRIPTION

This broke when we added this `isLiked` field to the comment query. We need to make sure we have it in the mutation, so we can safely insert the comment into the comment list cache. 

![2021-03-29 11 32 44](https://user-images.githubusercontent.com/1637694/112862527-da267100-9083-11eb-87d2-f340aff67835.gif)


### What does this PR do, or why is it needed?

### How do I test this PR?
