### PR TITLE
fix: Map nickName to firstName

### DIFF
--- a/packages/apollos-data-connector-postgres/src/people/resolver.js
+++ b/packages/apollos-data-connector-postgres/src/people/resolver.js
@@ -20,7 +20,7 @@ export default {
       birthDate ? moment(birthDate).toJSON() : null
     ),
     email: enforceCurrentUser(({ email }) => email),
-    nickName: ({ firstName, lastName }) => `${firstName} ${lastName}`,
+    nickName: ({ firstName }) => `${firstName}`,
     gender: ({ gender }) => startCase(toLower(gender)),
   },
   SearchPeopleResultsConnection: {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

We are now saving `nickName` to the `firstName` field using the shovel, so the nickName field should be just `firstName` (and probs deprecated some time soon) 

### How do I test this PR?
