### PR TITLE
chore: publish canary before stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,9 @@ jobs:
       run: |
         git config --global user.email "apps@apollos.app"
         git config --global user.name "Apollos Admin"
-        yarn release:canary --yes --force-publish
         yarn release --yes
+        git commit --allow-empty -m "chore: first canary build"
+        git push
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,8 @@ jobs:
       run: |
         git config --global user.email "apps@apollos.app"
         git config --global user.name "Apollos Admin"
-        yarn release --yes
         yarn release:canary --yes --force-publish
+        yarn release --yes
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, the first canary after the release fails because there's already a `.0`. This should be fine even if the version number doesn't reflect the conventional commits version, we only to need to make sure the canary is the latest possible code, version number is irrelevant
