### PR TITLE
feat: Follower request push notification opens to connect tab

### DIFF
--- a/packages/apollos-data-connector-postgres/__mocks__/@apollosproject/config.js
+++ b/packages/apollos-data-connector-postgres/__mocks__/@apollosproject/config.js
@@ -1,6 +1,9 @@
 const ApolloServer = require.requireActual('@apollosproject/config').default;
 
 ApolloServer.loadJs({
+  APP: {
+    DEEP_LINK_HOST: 'apolloschurchapp',
+  },
 });
 
 export default ApolloServer;

--- a/packages/apollos-data-connector-postgres/src/follows/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/__tests__/dataSource.js
@@ -102,6 +102,7 @@ describe('Apollos Postgres FollowRequest DataSource', () => {
     });
     expect(notificationMock.mock.calls[0][0].data).toEqual({
       requestPersonId: person1.apollosId,
+      url: 'apolloschurchapp://nav/Tabs?screen=Connect',
     });
     expect(notificationMock.mock.calls[0][0].buttons).toMatchSnapshot();
     expect(notificationMock.mock.calls[0][0].content).toMatchSnapshot();

--- a/packages/apollos-data-connector-postgres/src/follows/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/follows/dataSource.js
@@ -113,7 +113,10 @@ class Follow extends PostgresDataSource {
     return this.context.dataSources.OneSignal.createNotification({
       content: `${requestPerson.firstName} ${requestPerson.lastName} has asked to follow you.`,
       to: followedPerson,
-      data: { requestPersonId: requestPerson.apollosId },
+      data: {
+        requestPersonId: requestPerson.apollosId,
+        url: `${ApollosConfig?.APP?.DEEP_LINK_HOST}://nav/Tabs?screen=Connect`,
+      },
       buttons: [
         {
           id: `acceptFollowRequest`,


### PR DESCRIPTION
## DESCRIPTION

![29E31F61-F7BA-491A-9161-170920494E79_1_105_c](https://user-images.githubusercontent.com/1637694/113025267-c0555e80-9155-11eb-9d54-038799a0b638.jpeg)


### What does this PR do, or why is it needed?

We need to open up to the connect tab since iOS user's don't get the cool button.

### How do I test this PR?
