### PR TITLE
chore: decouple search channels from user feed

### DIFF
--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -3,17 +3,22 @@ import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
 import ApollosConfig from '@apollosproject/config';
 
 class ActionAlgorithm extends RockApolloDataSource {
-  // Names of Action Algoritms mapping to the functions that create the actions.
+  // Names of Action Algorithms mapping to the functions that create the actions.
   ACTION_ALGORITHMS = Object.entries({
-    // We need to make sure `this` refers to the class, not the `ACTION_ALGORITHIMS` object.
+    // We need to make sure `this` refers to the class, not the `ACTION_ALGORITHMS` object.
+    CONTENT_FEED: this.contentFeedAlgorithm,
     PERSONA_FEED: this.personaFeedAlgorithm,
+    //
+    // TODO deprecate these two
     CONTENT_CHANNEL: this.contentChannelAlgorithm,
+    USER_FEED: this.userFeedAlgorithm,
+    //
+    //
     SERMON_CHILDREN: this.sermonChildrenAlgorithm,
     LATEST_SERIES_CHILDREN: this.latestSeriesChildrenAlgorithm,
     UPCOMING_EVENTS: this.upcomingEventsAlgorithm,
     CAMPAIGN_ITEMS: this.campaignItemsAlgorithm,
     SERIES_IN_PROGRESS: this.seriesInProgressAlgorithm,
-    USER_FEED: this.userFeedAlgorithm,
     DAILY_PRAYER: this.dailyPrayerAlgorithm,
   }).reduce((accum, [key, value]) => {
     // convenciance code to make sure all methods are bound to the Features dataSource
@@ -114,8 +119,10 @@ class ActionAlgorithm extends RockApolloDataSource {
     }));
   }
 
+  // TODO deprecate, use CONTENT_FEED
   // Gets a configurable amount of content items from a specific content channel.
   async contentChannelAlgorithm({ contentChannelId, limit = null } = {}) {
+    console.warn('CONTENT_CHANNEL algorithm is deprecated, use CONTENT_FEED');
     if (contentChannelId == null) {
       throw new Error(
         `contentChannelId is a required argument for the CONTENT_CHANNEL ActionList algorithm.
@@ -230,7 +237,25 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
     }));
   }
 
+  async contentFeedAlgorithm({ channelIds = [], limit = 20 } = {}) {
+    const { ContentItem } = this.context.dataSources;
+
+    const items = await ContentItem.byChannelIds(channelIds).top(limit).get();
+
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: get(item, 'contentChannel.name'),
+      relatedNode: { ...item, __type: ContentItem.resolveType(item) },
+      image: ContentItem.getCoverImage(item),
+      action: 'READ_CONTENT',
+      summary: ContentItem.createSummary(item),
+    }));
+  }
+
+  // TODO deprecate, use CONTENT_FEED instead
   async userFeedAlgorithm({ limit = 20 } = {}) {
+    console.warn('USER_FEED algorithm is deprecated, use CONTENT_FEED');
     const { ContentItem } = this.context.dataSources;
 
     const items = await ContentItem.byUserFeed().top(limit).get();

--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -240,7 +240,9 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
   async contentFeedAlgorithm({ channelIds = [], limit = 20 } = {}) {
     const { ContentItem } = this.context.dataSources;
 
-    const items = await ContentItem.byChannelIds(channelIds).top(limit).get();
+    const items = await ContentItem.byContentChannelIds(channelIds)
+      .top(limit)
+      .get();
 
     return items.map((item, i) => ({
       id: `${item.id}${i}`,

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -18,6 +18,10 @@ const { APP, ROCK, ROCK_MAPPINGS, ROCK_CONSTANTS } = ApollosConfig;
 export default class ContentItem extends RockApolloDataSource {
   resource = 'ContentChannelItems';
 
+  activeChannelIds =
+    ROCK_MAPPINGS.ACTIVE_CONTENT_CHANNEL_IDS ||
+    ROCK_MAPPINGS.FEED_CONTENT_CHANNEL_IDS;
+
   attributeIsImage = ({ key, attributeValues, attributes }) =>
     attributes[key].fieldTypeId === ROCK_CONSTANTS.IMAGE ||
     (key.toLowerCase().includes('image') &&
@@ -457,15 +461,19 @@ export default class ContentItem extends RockApolloDataSource {
       .orderBy('StartDateTime', 'desc');
   };
 
+  byChannelIds = (channelIds = []) =>
+    this.request()
+      .filterOneOf(channelIds.map((id) => `ContentChannelId eq ${id}`))
+      .cache({ ttl: 60 })
+      .andFilter(this.LIVE_CONTENT());
+
   byUserFeed = () =>
     this.byActive().orderBy('StartDateTime', 'desc').expand('ContentChannel');
 
   byActive = () =>
     this.request()
       .filterOneOf(
-        ROCK_MAPPINGS.FEED_CONTENT_CHANNEL_IDS.map(
-          (id) => `ContentChannelId eq ${id}`
-        )
+        this.activeChannelIds.map((id) => `ContentChannelId eq ${id}`)
       )
       .cache({ ttl: 60 })
       .andFilter(this.LIVE_CONTENT());
@@ -473,9 +481,7 @@ export default class ContentItem extends RockApolloDataSource {
   byDateAndActive = async ({ datetime }) =>
     this.request()
       .filterOneOf(
-        ROCK_MAPPINGS.FEED_CONTENT_CHANNEL_IDS.map(
-          (id) => `ContentChannelId eq ${id}`
-        )
+        this.activeChannelIds.map((id) => `ContentChannelId eq ${id}`)
       )
       .cache({ ttl: 60 })
       .andFilter(

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -461,12 +461,6 @@ export default class ContentItem extends RockApolloDataSource {
       .orderBy('StartDateTime', 'desc');
   };
 
-  byChannelIds = (channelIds = []) =>
-    this.request()
-      .filterOneOf(channelIds.map((id) => `ContentChannelId eq ${id}`))
-      .cache({ ttl: 60 })
-      .andFilter(this.LIVE_CONTENT());
-
   byUserFeed = () =>
     this.byActive().orderBy('StartDateTime', 'desc').expand('ContentChannel');
 


### PR DESCRIPTION
This PR accomplishes two things:
1. Decouples the search indexed content from the user feed. Sometimes you want to be able to search for more than just what's in the user feed.
2. Replaces two algorithms with one.

Test using the `feeds` branch on templates
