### PR TITLE
chore: delay templates bump in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
       run: |
         git config --global user.email "apps@apollos.app"
         git config --global user.name "Apollos Admin"
+        sleep 120 # this is to insure the tag has been uploaded to Github and the API call will work
         yarn bump
 
   upgrade-tool:


### PR DESCRIPTION
I think what's happening is a foot race between the templates bump and the API propogating the tag they just received from us on the previous step
