### PR TITLE
fix: Optimize Cloudinary image settings

### DIFF
--- a/packages/apollos-data-connector-cloudinary/src/__tests__/cloudinary.tests.js
+++ b/packages/apollos-data-connector-cloudinary/src/__tests__/cloudinary.tests.js
@@ -39,7 +39,7 @@ describe('Cloudinary', () => {
     const url = withCloudinary(originalUrl);
 
     expect(url).toEqual(
-      'https://res.cloudinary.com/n07t21i7/image/fetch/c_limit,f_auto,q_auto:eco,w_1600/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Df54b0db0-95f5-44ad-b8f2-8bcd1b23cfdb'
+      'https://res.cloudinary.com/n07t21i7/image/fetch/c_limit,f_jpg,q_auto,w_750/https://apollosrock.newspring.cc/GetImage.ashx%3Fguid%3Df54b0db0-95f5-44ad-b8f2-8bcd1b23cfdb'
     );
   });
   it('must not double parse a cloudinary url.', () => {

--- a/packages/apollos-data-connector-cloudinary/src/cloudinary.js
+++ b/packages/apollos-data-connector-cloudinary/src/cloudinary.js
@@ -27,10 +27,10 @@ export default function withCloudinary(_url = '', options) {
   if (CLOUDINARY.URL) {
     return cloudinary.url(url, {
       type: 'fetch',
-      fetch_format: 'auto',
-      width: '1600',
+      fetch_format: 'jpg',
+      width: '750',
       crop: 'limit',
-      quality: 'auto:eco',
+      quality: 'auto',
       ...options,
     });
   }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The Cloudinary settings we had were pretty liberal and can result in large images. This forces the fetch format to jpg which forces Cloudinary to make images lossy, and makes the base image size smaller. Because of this, we can get rid of the `eco` setting we previously had. 

The same image that is several megabytes on Newspring's instance is now ~150kb.

### How do I test this PR?
