### PR TITLE
fix: component overrides for NodeSingleConnected

### DIFF
--- a/packages/apollos-ui-connected/src/NodeSingleConnected/index.js
+++ b/packages/apollos-ui-connected/src/NodeSingleConnected/index.js
@@ -95,7 +95,7 @@ const NodeSingleConnectedWithMedia = ({
 
       if (!hasMedia && !hasLivestream)
         return (
-          <NodeSingleConnected nodeId={nodeId} {...props}>
+          <NodeSingleConnected nodeId={nodeId} Component={Component} {...props}>
             {children}
           </NodeSingleConnected>
         );


### PR DESCRIPTION
Previously you could only set a custom `Component` if your node single had media. This is an edge case regression when the new media player was added

## DESCRIPTION

### What does this PR do, or why is it needed?

### How do I test this PR?
