### PR TITLE
feat: add series to series items

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -221,6 +221,26 @@ export default class ContentItem extends RockApolloDataSource {
     return features;
   }
 
+  getSeriesByChildId = async (childId) => {
+    const parentAssociations = await this.request(
+      'ContentChannelItemAssociations'
+    )
+      .filter(`ChildContentChannelItemId eq ${childId}`)
+      .cache({ ttl: 60 })
+      .get();
+
+    const seriesItems = await Promise.all(
+      parentAssociations.map(({ contentChannelItemId }) =>
+        this.getFromId(contentChannelItemId)
+      )
+    );
+
+    // get first match that also exists in the SERIES_CHANNEL_IDS list
+    return seriesItems.find(({ contentChannelId }) =>
+      ROCK_MAPPINGS.SERIES_CHANNEL_IDS.includes(contentChannelId)
+    );
+  };
+
   getAddCommentInitialPrompt = (attributeValues) => {
     return get(attributeValues, 'initialPrompt.value', 'Write Something...');
   };

--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -146,6 +146,8 @@ const resolver = {
   },
   ContentSeriesContentItem: {
     ...defaultContentItemResolvers,
+    series: ({ id }, __, { dataSources: { ContentItem } }) =>
+      ContentItem.getSeriesByChildId(id),
     upNext: (root, args, { dataSources }) =>
       dataSources.ContentItem.getUpNext(root),
     percentComplete: (root, args, { dataSources }) =>

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -507,6 +507,7 @@ export const contentItemSchema = gql`
       after: String
     ): ContentItemsConnection
     parentChannel: ContentChannel
+    series: ContentItem
     theme: Theme
     percentComplete: Float @cacheControl(maxAge: 0)
     upNext: ContentItem @cacheControl(maxAge: 0)


### PR DESCRIPTION
New approach to an old problem. We define the list of series IDs in the config. That will rule out possibly returning a campaign item as the series

test using the `series` branch on templates

<img width="2063" alt="Screen Shot 2021-04-06 at 11 20 33 AM" src="https://user-images.githubusercontent.com/2659478/113735565-59dabe00-96ca-11eb-97f1-1b0e6e52bcf7.png">

