### PR TITLE
fix: Buttons hiding too soon in editing modal on Android

### DIFF
--- a/packages/apollos-ui-kit/src/AddCommentInput/AddCommentInput.js
+++ b/packages/apollos-ui-kit/src/AddCommentInput/AddCommentInput.js
@@ -101,6 +101,7 @@ const AddCommentInput = ({
           editorTitle={editorTitle}
           confirmationTitle={confirmationTitle}
           showCancel={showCancel}
+          hiddenIndex={fullscreen ? -1 : 0}
         />
       </BottomSheetModal>
 

--- a/packages/apollos-ui-kit/src/AddCommentInput/Editor.js
+++ b/packages/apollos-ui-kit/src/AddCommentInput/Editor.js
@@ -94,6 +94,7 @@ const Editor = ({
   initialValue,
   showCancel,
   bottomSheetIndex,
+  hiddenIndex,
 }) => {
   const keyboardHeight = useKeyboardHeight();
   const text = useSharedValue(initialValue);
@@ -140,9 +141,9 @@ const Editor = ({
 
     // hide header when compressed
     runOnJS(setHeaderShown)(
-      textHasLength && (isEditing || bottomSheetIndex > 0)
+      textHasLength && (isEditing || bottomSheetIndex > hiddenIndex)
     );
-  }, [isEditing, bottomSheetIndex, setHeaderShown, text]);
+  }, [isEditing, bottomSheetIndex, setHeaderShown, text, hiddenIndex]);
 
   useEffect(() => {
     // not working on android 😭
@@ -199,7 +200,7 @@ const Editor = ({
       <CommentInputContainer
         style={Platform.select({
           android: {
-            paddingTop: headerShown ? 32 : 0, // TODO: Animate this.
+            paddingTop: headerShown ? 32 : 0,
           },
         })}
       >
@@ -260,9 +261,12 @@ Editor.propTypes = {
   }),
   initialValue: PropTypes.string,
   headerTitle: PropTypes.string,
-  bottomSheetIndex: PropTypes.shape({
-    value: PropTypes.number,
-  }),
+  bottomSheetIndex: PropTypes.number,
+  hiddenIndex: PropTypes.number,
+};
+
+Editor.defaultProps = {
+  hiddenIndex: 0,
 };
 
 export default Editor;

--- a/packages/apollos-ui-kit/src/AddCommentInput/Navigator.js
+++ b/packages/apollos-ui-kit/src/AddCommentInput/Navigator.js
@@ -20,46 +20,46 @@ const Navigator = ({
   prompt,
   initialValue,
   showCancel,
+  hiddenIndex,
   ...navigatorProps
-}) => {
-  return (
-    <NavigationContainer independent>
-      <Stack.Navigator {...navigatorProps}>
-        <Stack.Screen name="Editor">
-          {(props) => (
-            <Editor
-              bottomSheetModalRef={bottomSheetModalRef}
-              bottomSheetIndex={bottomSheetIndex}
-              image={profile?.photo}
-              prompt={prompt}
-              headerTitle={editorTitle}
-              initialValue={initialValue}
-              showCancel={showCancel}
-              {...props}
-            />
-          )}
-        </Stack.Screen>
-        <Stack.Screen
-          name="Confirmation"
-          options={{
-            headerShown: true,
-            headerTitle: confirmationTitle,
-            headerBackTitle: 'Edit',
-          }}
-        >
-          {(props) => (
-            <Confirmation
-              bottomSheetModalRef={bottomSheetModalRef}
-              profile={profile}
-              onSubmit={onSubmit}
-              {...props}
-            />
-          )}
-        </Stack.Screen>
-      </Stack.Navigator>
-    </NavigationContainer>
-  );
-};
+}) => (
+  <NavigationContainer independent>
+    <Stack.Navigator {...navigatorProps}>
+      <Stack.Screen name="Editor">
+        {(props) => (
+          <Editor
+            bottomSheetModalRef={bottomSheetModalRef}
+            bottomSheetIndex={bottomSheetIndex}
+            image={profile?.photo}
+            prompt={prompt}
+            headerTitle={editorTitle}
+            initialValue={initialValue}
+            showCancel={showCancel}
+            hiddenIndex={hiddenIndex}
+            {...props}
+          />
+        )}
+      </Stack.Screen>
+      <Stack.Screen
+        name="Confirmation"
+        options={{
+          headerShown: true,
+          headerTitle: confirmationTitle,
+          headerBackTitle: 'Edit',
+        }}
+      >
+        {(props) => (
+          <Confirmation
+            bottomSheetModalRef={bottomSheetModalRef}
+            profile={profile}
+            onSubmit={onSubmit}
+            {...props}
+          />
+        )}
+      </Stack.Screen>
+    </Stack.Navigator>
+  </NavigationContainer>
+);
 
 Navigator.propTypes = {
   prompt: PropTypes.string,
@@ -76,6 +76,7 @@ Navigator.propTypes = {
   confirmationTitle: PropTypes.string,
   bottomSheetIndex: PropTypes.shape({}),
   showCancel: PropTypes.bool,
+  hiddenIndex: PropTypes.number,
 };
 
 const EnhancedNavigator = withTheme(({ theme, ...props }) => ({


### PR DESCRIPTION
## DESCRIPTION

For the editor window, the initial bottomSheetIndex was 0 (since the component was full screen). 

![2021-04-09 15 13 02](https://user-images.githubusercontent.com/1637694/114230810-98c97780-9947-11eb-8b50-da0ff2806134.gif)
![2021-04-09 15 11 09](https://user-images.githubusercontent.com/1637694/114230857-a5e66680-9947-11eb-9323-b05721dc5bdf.gif)



### What does this PR do, or why is it needed?

### How do I test this PR?
