### PR TITLE
chore: deprecate PushConsumer

### DIFF
--- a/packages/apollos-ui-notifications/src/pushProvider.js
+++ b/packages/apollos-ui-notifications/src/pushProvider.js
@@ -72,6 +72,7 @@ class Provider extends PureComponent {
   }
 }
 
+// TODO deprecated
 export const PushConsumer = PushContext.Consumer;
 
 export default Provider;


### PR DESCRIPTION
We are already exporting the `PushContext`
