### PR TITLE
fix: correctly gets content sharing url

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -98,9 +98,7 @@ export const defaultContentItemResolvers = {
   theme: () => null, // todo: integrate themes from Rock
 
   sharing: (root, args, { dataSources: { ContentItem } }) => ({
-    url: ContentItem.getShareUrl({
-      contentId: root.id,
-    }),
+    url: ContentItem.getShareUrl(root),
     title: 'Share via ...',
     message: `${root.title} - ${ContentItem.createSummary(root)}`,
   }),


### PR DESCRIPTION
Not sure how I missed this the first time, this is going to break every time because it doesn't have what it needs for `resolveType`
