### PR TITLE
chore: move HTML content resolver to data source

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/resolver.js
+++ b/packages/apollos-data-connector-rock/src/content-items/resolver.js
@@ -1,8 +1,5 @@
-/* eslint-disable prefer-template */
-
 import { get } from 'lodash';
 import moment from 'moment-timezone';
-import sanitizeHtml from 'sanitize-html';
 import {
   createGlobalId,
   withEdgePagination,
@@ -14,46 +11,8 @@ const { ROCK, ROCK_MAPPINGS } = ApollosConfig;
 export const defaultContentItemResolvers = {
   id: ({ id }, args, context, { parentType }) =>
     createGlobalId(id, parentType.name),
-  htmlContent: ({ content }) =>
-    sanitizeHtml(content, {
-      allowedTags: [
-        'h1',
-        'h2',
-        'h3',
-        'h4',
-        'h5',
-        'h6',
-        'blockquote',
-        'p',
-        'a',
-        'ul',
-        'ol',
-        'li',
-        'b',
-        'i',
-        'strong',
-        'em',
-        'br',
-        'caption',
-        'img',
-        'div',
-      ],
-      allowedAttributes: {
-        a: ['href', 'target'],
-        img: ['src'],
-      },
-      transformTags: {
-        img: (tagName, { src }) => {
-          return {
-            tagName,
-            attribs: {
-              // adds Rock URL in the case of local image references in the CMS
-              src: src.startsWith('http') ? src : `${ROCK.URL || ''}${src}`,
-            },
-          };
-        },
-      },
-    }),
+  htmlContent: ({ content }, _, { dataSources }) =>
+    dataSources.ContentItem.createHTMLContent(content),
   childContentItemsConnection: async ({ id }, args, { dataSources }) =>
     dataSources.ContentItem.paginate({
       cursor: await dataSources.ContentItem.getCursorByParentContentItemId(id),


### PR DESCRIPTION
This allows someone to customize the resolver function properly
