### PR TITLE
fix: Add an auth error if a user is not in Postgres

### DIFF
--- a/packages/apollos-data-connector-postgres/src/people/__tests__/__snapshots__/dataSource.js.snap
+++ b/packages/apollos-data-connector-postgres/src/people/__tests__/__snapshots__/dataSource.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Apollos Postgres People DataSource should throw an error if current user isnt in the db 1`] = `"Invalid Credentials"`;

--- a/packages/apollos-data-connector-postgres/src/people/__tests__/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/people/__tests__/dataSource.js
@@ -63,6 +63,25 @@ describe('Apollos Postgres People DataSource', () => {
     expect(person.id).toBeDefined();
   });
 
+  it('should find a current user id', async () => {
+    const currentPerson = await peopleDataSource.model.create({
+      originId: '1',
+      originType: 'rock',
+      firstName: 'Vincent',
+      lastName: 'Wilson',
+    });
+
+    const fetchedId = await peopleDataSource.getCurrentPersonId();
+
+    expect(fetchedId).toBe(currentPerson.id);
+  });
+
+  it('should throw an error if current user isnt in the db', () => {
+    const getPerson = peopleDataSource.getCurrentPersonId();
+
+    expect(getPerson).rejects.toThrowErrorMatchingSnapshot();
+  });
+
   it('should find a user by postgres id', async () => {
     const newPerson = await peopleDataSource.model.create({
       originId: '1',

--- a/packages/apollos-data-connector-postgres/src/people/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/people/dataSource.js
@@ -146,6 +146,12 @@ export default class Person extends PostgresDataSource {
     }
     const currentPersonWhere = await this.whereCurrentPerson();
     const person = await this.model.findOne({ where: currentPersonWhere });
+
+    if (!person) {
+      // We've seen this happen in a few instances related to deduping.
+      // Best bet is to log the user out and give them another chance to sign in.
+      throw new AuthenticationError('Invalid Credentials');
+    }
     // cache the current user on the context. avoids oft repeated n+1 queries.
     // this is a huge win, but we need to identify a more elegant way to do this in the future.
     this.context.currentPostgresPerson = person;


### PR DESCRIPTION
A hack to mask what is potentially an isolated but trickier problem to solve. If user exists in the context of `getCurrentPerson`, but doesn't in Postgres, we should log that user out. In the past, similar problems would fail silently but we'll need to raise an exception. 