### PR TITLE
chore: use default bugsnag release stage

### DIFF
--- a/packages/apollos-bugsnag/src/index.js
+++ b/packages/apollos-bugsnag/src/index.js
@@ -9,7 +9,6 @@ const isDev =
 if (ApollosConfig.BUGSNAG && ApollosConfig.BUGSNAG.API_KEY) {
   Bugsnag.start({
     apiKey: ApollosConfig.BUGSNAG.API_KEY,
-    releaseStage: process.env.RELEASE_STAGE || 'development',
     ...ApollosConfig.BUGSNAG.OPTIONS,
   });
 } else {


### PR DESCRIPTION
uses `development` if localhost is in the URL, else `production`
