### PR TITLE
chore: remove redundant config variable

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -23,6 +23,8 @@ export default class ContentItem extends RockApolloDataSource {
   resource = 'ContentChannelItems';
 
   activeChannelIds =
+    ROCK_MAPPINGS.ALL_CONTENT_CHANNELS ||
+    // TODO deprecated variables
     ROCK_MAPPINGS.ACTIVE_CONTENT_CHANNEL_IDS ||
     ROCK_MAPPINGS.FEED_CONTENT_CHANNEL_IDS;
 


### PR DESCRIPTION
This uses the new \`ALL_CONTENT_CHANNELS\` variable for active content and search indexing
