### PR TITLE
chore: add group type defaults

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/resolvers.tests.js
@@ -98,11 +98,6 @@ ApollosConfig.loadJs({
     IMAGE_URL: 'https://apollosrock.newspring.cc/GetImage.ashx',
     TIMEZONE: 'America/New_York',
   },
-  ROCK_CONSTANTS: {
-    IMAGE: 10,
-    AUDIO_FILE: 77,
-    VIDEO_FILE: 79,
-  },
   ROCK_MAPPINGS: {
     FEED_CONTENT_CHANNEL_IDS: [1, 2, 3, 4, 6, 8],
     SERIES_CONTENT_CHANNEL_TYPE_IDS: [6, 7],

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -17,7 +17,7 @@ import {
 
 import { createImageUrlFromGuid } from '../utils';
 
-const { ROCK, ROCK_MAPPINGS, ROCK_CONSTANTS } = ApollosConfig;
+const { ROCK, ROCK_MAPPINGS } = ApollosConfig;
 
 export default class ContentItem extends RockApolloDataSource {
   resource = 'ContentChannelItems';
@@ -27,21 +27,21 @@ export default class ContentItem extends RockApolloDataSource {
     ROCK_MAPPINGS.FEED_CONTENT_CHANNEL_IDS;
 
   attributeIsImage = ({ key, attributeValues, attributes }) =>
-    attributes[key].fieldTypeId === ROCK_CONSTANTS.IMAGE ||
+    attributes[key].fieldTypeId === 10 || // Image
     (key.toLowerCase().includes('image') &&
       typeof attributeValues[key].value === 'string' &&
       attributeValues[key].value.startsWith('http')); // looks like an image url
 
   attributeIsVideo = ({ key, attributeValues, attributes }) =>
-    attributes[key].fieldTypeId === ROCK_CONSTANTS.VIDEO_FILE ||
-    attributes[key].fieldTypeId === ROCK_CONSTANTS.VIDEO_URL ||
+    attributes[key].fieldTypeId === 79 || // video file
+    attributes[key].fieldTypeId === 80 || // video url
     (key.toLowerCase().includes('video') &&
       typeof attributeValues[key].value === 'string' &&
       attributeValues[key].value.startsWith('http')); // looks like a video url
 
   attributeIsAudio = ({ key, attributeValues, attributes }) =>
-    attributes[key].fieldTypeId === ROCK_CONSTANTS.AUDIO_FILE ||
-    attributes[key].fieldTypeId === ROCK_CONSTANTS.AUDIO_URL ||
+    attributes[key].fieldTypeId === 77 || // audio file
+    attributes[key].fieldTypeId === 78 || // audio url
     (key.toLowerCase().includes('audio') &&
       typeof attributeValues[key].value === 'string' &&
       attributeValues[key].value.startsWith('http')); // looks like an audio url

--- a/packages/apollos-data-connector-rock/src/groups/__tests__/__snapshots__/data-source.test.js.snap
+++ b/packages/apollos-data-connector-rock/src/groups/__tests__/__snapshots__/data-source.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Groups should get a group by id 1`] = `
 Object {
+  "groupTypeId": 25,
   "id": 1,
   "isActive": true,
   "isArchived": false,
@@ -45,12 +46,14 @@ Array [
 exports[`Groups should get groups by person 1`] = `
 Array [
   Object {
+    "groupTypeId": 25,
     "id": 1,
     "isActive": true,
     "isArchived": false,
     "name": "franks beer group",
   },
   Object {
+    "groupTypeId": 25,
     "id": 1,
     "isActive": true,
     "isArchived": false,

--- a/packages/apollos-data-connector-rock/src/groups/__tests__/data-source.test.js
+++ b/packages/apollos-data-connector-rock/src/groups/__tests__/data-source.test.js
@@ -10,6 +10,7 @@ describe('Groups', () => {
   const groupMock = Promise.resolve({
     id: 1,
     name: 'franks beer group',
+    groupTypeId: 25,
     isActive: true,
     isArchived: false,
   });

--- a/packages/apollos-data-connector-rock/src/groups/data-source.js
+++ b/packages/apollos-data-connector-rock/src/groups/data-source.js
@@ -7,10 +7,11 @@ export default class Group extends RockApolloDataSource {
 
   expanded = true;
 
+  // these are standard across rock
   groupTypeMap = {
-    Serving: ROCK_MAPPINGS.SERVING_GROUP_TYPE_ID,
-    Community: ROCK_MAPPINGS.COMMUNITY_GROUP_TYPE_ID,
-    Family: ROCK_MAPPINGS.FAMILY_GROUP_TYPE_ID,
+    Serving: ROCK_MAPPINGS.SERVING_GROUP_TYPE_ID || 23,
+    Community: ROCK_MAPPINGS.COMMUNITY_GROUP_TYPE_ID || 25,
+    Family: ROCK_MAPPINGS.FAMILY_GROUP_TYPE_ID || 10,
   };
 
   getFromId = ({ id }) => this.request().find(id).expand('Members').get();

--- a/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
@@ -22,7 +22,7 @@ export default class PersonalDevices extends RockApolloDataSource {
       PersonAliasId: currentUser.primaryAliasId,
       DeviceRegistrationId: pushId,
       PersonalDeviceTypeValueId:
-        ApollosConfig.ROCK_MAPPINGS.MOBILE_DEVICE_TYPE_ID,
+        ApollosConfig.ROCK_MAPPINGS.MOBILE_DEVICE_TYPE_ID || 671,
       NotificationsEnabled: 1,
       IsActive: 1,
     });


### PR DESCRIPTION
also removes the HUGE rock constants section that we've never had to touch, only 5 of the items are used anyway and in the extremely unlikely chance there's a change required, they could just overwrite the DS function.