### PR TITLE
fix: prevents error when logging in for the first time

### DIFF
--- a/packages/apollos-data-connector-rock/src/auth/data-source.js
+++ b/packages/apollos-data-connector-rock/src/auth/data-source.js
@@ -54,7 +54,7 @@ export default class AuthDataSource extends RockApolloDataSource {
     });
     if (!cachedUserName) {
       throw new AuthenticationError(
-        'Invalid user cookie; no eligble user login found'
+        'Invalid user cookie; no eligble user cached'
       );
     }
     const login = await this.request('/UserLogins')
@@ -101,28 +101,30 @@ export default class AuthDataSource extends RockApolloDataSource {
 
   authenticate = async ({ identity, password }) => {
     const { Cache } = this.context.dataSources;
+    let cookie;
     try {
-      const cookie = await this.fetchUserCookie(identity, password);
-      const sessionId = await this.createSession({ cookie });
-      const token = generateToken({ cookie, sessionId });
-      this.context.rockCookie = cookie;
-      this.context.userToken = token;
-      this.context.sessionId = sessionId;
-      Cache.set({
-        key: `:userLogins:${crypto
-          .createHash('sha1')
-          .update(cookie)
-          .digest('hex')}`,
-        data: identity,
-        expiresIn: 31556952, // one year
-      });
-      return { token, rockCookie: cookie };
+      cookie = await this.fetchUserCookie(identity, password);
     } catch (e) {
       if (e instanceof AuthenticationError) {
         throw new UserInputError('Username or Password incorrect');
       }
       throw e;
     }
+    Cache.set({
+      key: `:userLogins:${crypto
+        .createHash('sha1')
+        .update(cookie)
+        .digest('hex')}`,
+      data: identity,
+      expiresIn: 31556952, // one year
+    });
+
+    const sessionId = await this.createSession({ cookie });
+    const token = generateToken({ cookie, sessionId });
+    this.context.rockCookie = cookie;
+    this.context.userToken = token;
+    this.context.sessionId = sessionId;
+    return { token, rockCookie: cookie };
   };
 
   personExists = async ({ identity }) => {


### PR DESCRIPTION
This fixes three things:
1. makes cached cookie auth error more explicit
2. narrows overbearing try-catch
3. sets cookie in cache before lookup

Was showing itself as the attached screenshot and was very hard to track down because of all the nested try/catch statements.

<img width="540" alt="Screen Shot 2021-05-06 at 4 32 13 PM" src="https://user-images.githubusercontent.com/2659478/117361924-9f84d500-ae88-11eb-8f86-26e4e89567b1.png">

