### PR TITLE
feat: add new tab feed query

### DIFF
--- a/packages/apollos-data-connector-rock/src/feature-feeds/index.js
+++ b/packages/apollos-data-connector-rock/src/feature-feeds/index.js
@@ -4,6 +4,11 @@ import ApollosConfig from '@apollosproject/config';
 
 const resolver = {
   Query: {
+    tabFeedFeatures: (root, args, { dataSources: { FeatureFeed } }) =>
+      FeatureFeed.getFeed({
+        type: 'tab',
+        args,
+      }),
     homeFeedFeatures: (root, args, { dataSources: { FeatureFeed } }) =>
       FeatureFeed.getFeed({
         type: 'apollosConfig',
@@ -46,6 +51,12 @@ class FeatureFeed extends RockApolloDataSource {
     let getFeatures = () => [];
     const { Feature, ContentItem } = this.context.dataSources;
 
+    if (type === 'tab') {
+      getFeatures = () =>
+        Feature.getFeatures(ApollosConfig.TABS[args.tab] || [], args);
+    }
+
+    // TODO deprecated
     if (type === 'apollosConfig') {
       getFeatures = () =>
         Feature.getFeatures(ApollosConfig[args.section] || [], args);

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -1034,7 +1034,7 @@ export const featuresSchema = gql`
   }
 
   extend type Query {
-    tabFeedFeatures(tab!: Tab, campusId: ID): FeatureFeed
+    tabFeedFeatures(tab: Tab!, campusId: ID): FeatureFeed
       @cacheControl(maxAge: 0)
     userFeedFeatures: [Feature]
       @cacheControl(maxAge: 0)

--- a/packages/apollos-data-schema/src/index.js
+++ b/packages/apollos-data-schema/src/index.js
@@ -1034,11 +1034,24 @@ export const featuresSchema = gql`
   }
 
   extend type Query {
+    tabFeedFeatures(tab!: Tab, campusId: ID): FeatureFeed
+      @cacheControl(maxAge: 0)
     userFeedFeatures: [Feature]
       @cacheControl(maxAge: 0)
       @deprecated(reason: "Use homeFeedFeatures or discoverFeedFeatures")
-    homeFeedFeatures(campusId: ID): FeatureFeed @cacheControl(maxAge: 0)
-    discoverFeedFeatures: FeatureFeed @cacheControl(maxAge: 0)
+    homeFeedFeatures(campusId: ID): FeatureFeed
+      @cacheControl(maxAge: 0)
+      @deprecated(reason: "Use tabFeedFeatures(tab: HOME)")
+    discoverFeedFeatures: FeatureFeed
+      @cacheControl(maxAge: 0)
+      @deprecated(reason: "Use tabFeedFeatures(tab: DISCOVER)")
+  }
+
+  enum Tab {
+    HOME
+    READ
+    WATCH
+    PRAY
   }
 `;
 


### PR DESCRIPTION
Gives us a simple way to create more queries for more tabs without polluting the schema

test using the `tab-component` branch on templates

<img width="602" alt="Screen Shot 2021-05-12 at 9 35 41 AM" src="https://user-images.githubusercontent.com/2659478/117984167-9a4edc80-b305-11eb-99b8-95e9e451732d.png">

