### PR TITLE
fix: remove auth navigation headers

### DIFF
--- a/packages/apollos-ui-auth/src/Password/PasswordEntryConnected.js
+++ b/packages/apollos-ui-auth/src/Password/PasswordEntryConnected.js
@@ -3,14 +3,17 @@ import React from 'react';
 import { Formik } from 'formik';
 import * as Yup from 'yup';
 import PropTypes from 'prop-types';
+import ApollosConfig from '@apollosproject/config';
 
 import { LoginConsumer } from '../LoginProvider';
 import PasswordEntry from './PasswordEntry';
 
+const { APP_DATA_URL } = ApollosConfig;
+
 const PasswordEntryConnected = ({
   navigation,
   route: {
-    params: { forgotPasswordURL },
+    params: { forgotPasswordURL = `${APP_DATA_URL}/forgot-password` },
   },
 }) => (
   <LoginConsumer>
@@ -64,11 +67,6 @@ PasswordEntryConnected.propTypes = {
   route: PropTypes.shape({
     params: PropTypes.shape({ forgotPasswordURL: PropTypes.string }),
   }),
-  emailRequired: PropTypes.bool,
-};
-
-PasswordEntryConnected.defaultProps = {
-  emailRequired: true,
 };
 
 export default PasswordEntryConnected;

--- a/packages/apollos-ui-auth/src/Profile/ProfileEntryConnected.js
+++ b/packages/apollos-ui-auth/src/Profile/ProfileEntryConnected.js
@@ -42,7 +42,6 @@ const ProfileEntryConnected = ({ navigation, profileSchema, Component }) => (
 
 ProfileEntryConnected.propTypes = {
   navigation: PropTypes.shape({ goBack: PropTypes.func.isRequired }).isRequired,
-  emailRequired: PropTypes.bool,
   profileSchema: PropTypes.shape({}),
   Component: PropTypes.oneOfType([
     PropTypes.node,
@@ -52,7 +51,6 @@ ProfileEntryConnected.propTypes = {
 };
 
 ProfileEntryConnected.defaultProps = {
-  emailRequired: true,
   profileSchema: ProfileSchema,
   Component: ProfileEntry,
 };

--- a/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntryConnected.js
+++ b/packages/apollos-ui-auth/src/ProfileDetails/ProfileDetailsEntryConnected.js
@@ -43,7 +43,6 @@ const ProfileDetailsEntryConnected = ({ navigation, Component }) => (
 
 ProfileDetailsEntryConnected.propTypes = {
   navigation: PropTypes.shape({ goBack: PropTypes.func.isRequired }).isRequired,
-  emailRequired: PropTypes.bool,
   Component: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.func,
@@ -52,7 +51,6 @@ ProfileDetailsEntryConnected.propTypes = {
 };
 
 ProfileDetailsEntryConnected.defaultProps = {
-  emailRequired: true,
   Component: ProfileEntry,
 };
 

--- a/packages/apollos-ui-auth/src/SMS/PhoneEntryConnected.js
+++ b/packages/apollos-ui-auth/src/SMS/PhoneEntryConnected.js
@@ -61,7 +61,7 @@ class PhoneEntryConnected extends Component {
   };
 
   handleOnPressAlternateLogin = () => {
-    this.props.navigation.replace('Identity');
+    this.props.navigation.replace('AuthEmailEntryConnected');
   };
 
   render() {

--- a/packages/apollos-ui-auth/src/SMS/PhoneEntryConnected.js
+++ b/packages/apollos-ui-auth/src/SMS/PhoneEntryConnected.js
@@ -61,7 +61,7 @@ class PhoneEntryConnected extends Component {
   };
 
   handleOnPressAlternateLogin = () => {
-    this.props.navigation.replace('AuthEmailEntryConnected');
+    this.props.navigation.replace('Identity');
   };
 
   render() {

--- a/packages/apollos-ui-auth/src/index.js
+++ b/packages/apollos-ui-auth/src/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 import { withTheme } from '@apollosproject/ui-kit';
 import PropTypes from 'prop-types';
-import hoistNonReactStatic from 'hoist-non-react-statics';
 
 import {
   SMSPhoneEntryConnected as AuthSMSPhoneEntryConnected,
@@ -23,11 +22,11 @@ import {
   ProfileDetailsEntryConnected as AuthProfileDetailsEntryConnected,
 } from './ProfileDetails';
 
-export LoginButton from './LoginButton';
-export ProtectedAction from './ProtectedAction';
-export ProtectedTouchable from './ProtectedTouchable';
-export AuthProvider, { AuthConsumer } from './Provider';
-export ProtectedRoute from './ProtectedRoute';
+export { default as LoginButton } from './LoginButton';
+export { default as ProtectedAction } from './ProtectedAction';
+export { default as ProtectedTouchable } from './ProtectedTouchable';
+export { default as AuthProvider, AuthConsumer } from './Provider';
+export { default as ProtectedRoute } from './ProtectedRoute';
 
 export {
   AUTHENTICATE,
@@ -39,9 +38,10 @@ export {
   VERIFY_PIN,
 } from './mutations';
 export { GET_LOGIN_STATE, GET_USER_EXISTS } from './queries';
-export authLink from './authLink';
-export buildErrorLink from './buildErrorLink';
-export Entry from './Entry';
+export { default as authLink } from './authLink';
+export { default as buildErrorLink } from './buildErrorLink';
+export { default as Entry } from './Entry';
+
 export * from './LoginProvider';
 
 export {
@@ -66,10 +66,10 @@ const AuthNavigator = ({
   confirmationPromptText,
   confirmationTitleText,
   forgotPasswordURL,
-  emailRequired,
   passwordPromptText,
+  screenOptions,
 }) => (
-  <AuthStack.Navigator initialRouteName="AuthIdentity" headerMode="none">
+  <AuthStack.Navigator screenOptions={screenOptions}>
     <AuthStack.Screen name="Identity">
       {() => (
         <IdentityStack.Navigator
@@ -90,47 +90,50 @@ const AuthNavigator = ({
     </AuthStack.Screen>
     <AuthStack.Screen
       name="AuthSMSVerificationConnected"
-      options={{ headerShown: true }}
       component={AuthSMSVerificationConnected}
+      options={{ headerShown: true }}
       initialParams={{ confirmationTitleText, confirmationPromptText }}
     />
     <AuthStack.Screen
       name="AuthPasswordEntryConnected"
-      options={{ headerShown: true }}
       component={AuthPasswordEntryConnected}
-      initialParams={{ forgotPasswordURL, passwordPromptText, emailRequired }}
+      options={{ headerShown: true }}
+      initialParams={{ forgotPasswordURL, passwordPromptText }}
     />
     <AuthStack.Screen
       name="AuthProfileEntryConnected"
       component={AuthProfileEntryConnected}
-      initialParams={{ emailRequired }}
     />
     <AuthStack.Screen
       name="AuthProfileDetailsEntryConnected"
       component={AuthProfileDetailsEntryConnected}
-      initialParams={{ emailRequired }}
     />
-
-    {/* Redirects */}
-    <AuthStack.Screen name="AuthSMSPhoneEntryConnected">
-      {({ navigation }) =>
-        navigation.replace('Identity', {
-          screen: 'AuthSMSPhoneEntryConnected',
-        }) || null
-      }
-    </AuthStack.Screen>
-    <AuthStack.Screen name="AuthEmailEntryConnected">
-      {({ navigation }) =>
-        navigation.replace('Identity', {
-          screen: 'AuthEmailEntryConnected',
-        }) || null
-      }
-    </AuthStack.Screen>
   </AuthStack.Navigator>
 );
 
-const ThemedAuthNavigator = withTheme(({ theme, ...props }) => ({
-  ...props,
+AuthNavigator.propTypes = {
+  alternateLoginText: PropTypes.string,
+  authTitleText: PropTypes.string,
+  confirmationTitleText: PropTypes.string,
+  confirmationPromptText: PropTypes.string,
+  passwordPromptText: PropTypes.string,
+  forgotPasswordURL: PropTypes.string,
+  screenOptions: PropTypes.shape({
+    headerTintColor: PropTypes.string,
+    headerTitleStyle: PropTypes.shape({
+      color: PropTypes.string,
+    }),
+    headerStyle: PropTypes.shape({
+      backgroundColor: PropTypes.string,
+    }),
+    headerHideShadow: PropTypes.bool,
+    headerTitle: PropTypes.string,
+    headerBackTitle: PropTypes.string,
+    headerShown: PropTypes.bool,
+  }),
+};
+
+const ThemedAuthNavigator = withTheme(({ theme }) => ({
   screenOptions: {
     headerTintColor: theme.colors.action.secondary,
     headerTitleStyle: {
@@ -146,17 +149,4 @@ const ThemedAuthNavigator = withTheme(({ theme, ...props }) => ({
   },
 }))(AuthNavigator);
 
-AuthNavigator.propTypes = {
-  alternateLoginText: PropTypes.string,
-  authTitleText: PropTypes.string,
-  confirmationTitleText: PropTypes.string,
-  confirmationPromptText: PropTypes.string,
-  passwordPromptText: PropTypes.string,
-  emailRequired: PropTypes.bool,
-  forgotPasswordURL: PropTypes.string,
-};
-
-const Auth = (props) => <ThemedAuthNavigator {...props} />;
-hoistNonReactStatic(Auth, AuthNavigator);
-
-export default Auth;
+export default ThemedAuthNavigator;

--- a/packages/apollos-ui-kit/src/NavigationService/index.js
+++ b/packages/apollos-ui-kit/src/NavigationService/index.js
@@ -41,9 +41,7 @@ const dispatch = (...args) => {
 const resetToAuth = performWhenReady(() => {
   _navigator.reset({
     index: 0,
-    routes: [
-      { name: 'Auth', params: { screen: 'AuthSMSPhoneEntryConnected' } },
-    ],
+    routes: [{ name: 'Auth', params: { screen: 'Identity' } }],
   });
 });
 


### PR DESCRIPTION
Cleans up a lot of other navigator code too. Test with `auth` branch in templates.

<img width="602" alt="Screen Shot 2021-05-12 at 1 04 59 PM" src="https://user-images.githubusercontent.com/2659478/118015815-b01eca80-b322-11eb-97ad-8793f84197c6.png">

