### PR TITLE
chore: allow default DB options

### DIFF
--- a/packages/apollos-data-connector-postgres/src/postgres/index.js
+++ b/packages/apollos-data-connector-postgres/src/postgres/index.js
@@ -59,7 +59,14 @@ const localConnect = () =>
 const sequelize = ApollosConfig?.DATABASE?.URL
   ? new Sequelize(ApollosConfig?.DATABASE?.URL, {
       ...sequelizeConfigOptions,
-      ...(ApollosConfig?.DATABASE?.OPTIONS || {}),
+      ...(ApollosConfig?.DATABASE?.OPTIONS ||
+      ApollosConfig.DATABASE.URL.includes('localhost')
+        ? {}
+        : {
+            dialectOptions: {
+              ssl: { require: true, rejectUnauthorized: true },
+            },
+          }),
     })
   : localConnect();
 


### PR DESCRIPTION
allows us to remove the options section of the config and take the guess work out of what it should be in different situations
