### PR TITLE
feat: get comment feature from parents

### DIFF
--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/__snapshots__/data-source.tests.js.snap
@@ -857,6 +857,52 @@ Array [
 ]
 `;
 
+exports[`ContentItemsModel returns comment features when a contentItem has a parent with a Comments field set to true 1`] = `
+Array [
+  Object {
+    "__typename": "AddCommentFeature",
+    "addPrompt": "What stands out to you?",
+    "id": "AddCommentFeature:123",
+    "initialPrompt": "Write Something...",
+  },
+  Object {
+    "__typename": "CommentListFeature",
+    "comments": Array [],
+    "id": "CommentListFeature:123",
+  },
+]
+`;
+
+exports[`ContentItemsModel returns comment features when a contentItem has a parent with a Comments field set to true 2`] = `
+Array [
+  Array [
+    Object {
+      "flagLimit": 0,
+      "nodeId": "ContentItem:123Test",
+      "nodeType": "UniversalContentItem",
+    },
+  ],
+]
+`;
+
+exports[`ContentItemsModel returns comment features when a contentItem has a parent with a Comments field set to true 3`] = `
+Array [
+  Array [
+    Object {
+      "addPrompt": "What stands out to you?",
+      "initialPrompt": "Write Something...",
+      "nodeId": "ContentItem:123Test",
+      "nodeType": "UniversalContentItem",
+      "relatedNode": Object {
+        "attributeValues": Object {},
+        "attributes": Object {},
+        "id": "ContentItem:123Test",
+      },
+    },
+  ],
+]
+`;
+
 exports[`ContentItemsModel returns features when a contentItem has a Features field 1`] = `
 Array [
   Object {

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
@@ -350,6 +350,46 @@ describe('ContentItemsModel', () => {
     expect(createAddCommentFeature.mock.calls).toMatchSnapshot();
   });
 
+  it('returns comment features when a contentItem has a parent with a Comments field set to true', async () => {
+    const dataSource = new ContentItemsDataSource();
+    const createCommentListFeature = jest.fn(() => ({
+      id: 'CommentListFeature:123',
+      comments: [],
+      __typename: 'CommentListFeature',
+    }));
+    const createAddCommentFeature = jest.fn(() => ({
+      id: 'AddCommentFeature:123',
+      initialPrompt: 'Write Something...',
+      addPrompt: 'What stands out to you?',
+      __typename: 'AddCommentFeature',
+    }));
+    dataSource.context = {
+      dataSources: {
+        Feature: {
+          createCommentListFeature,
+          createAddCommentFeature,
+        },
+      },
+    };
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () =>
+        Promise.resolve([
+          {
+            attributeValues: { childrenHaveComments: { value: 'True' } },
+            attributes: {},
+          },
+        ]),
+    });
+    const result = await dataSource.getFeatures({
+      attributeValues: {},
+      attributes: {},
+      id: 'ContentItem:123Test',
+    });
+    expect(result).toMatchSnapshot();
+    expect(createCommentListFeature.mock.calls).toMatchSnapshot();
+    expect(createAddCommentFeature.mock.calls).toMatchSnapshot();
+  });
+
   it('returns a text feature when a contentItem has a TextFeature field', async () => {
     const dataSource = new ContentItemsDataSource();
     const createTextFeature = jest.fn(() => ({

--- a/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
+++ b/packages/apollos-data-connector-rock/src/content-items/__tests__/data-source.tests.js
@@ -295,7 +295,10 @@ describe('ContentItemsModel', () => {
         },
       },
     };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: {
         features: {
           id: 123,
@@ -329,7 +332,10 @@ describe('ContentItemsModel', () => {
         },
       },
     };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: {
         comments: {
           id: 123,
@@ -351,7 +357,10 @@ describe('ContentItemsModel', () => {
       body: 'something',
     }));
     dataSource.context = { dataSources: { Feature: { createTextFeature } } };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: { textFeature: { id: 123, value: 'something' } },
     });
     expect(result).toMatchSnapshot();
@@ -365,7 +374,10 @@ describe('ContentItemsModel', () => {
       body: 'something',
     }));
     dataSource.context = { dataSources: { Feature: { createTextFeature } } };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: {
         textFeatures: {
           id: 123,
@@ -386,7 +398,10 @@ describe('ContentItemsModel', () => {
     dataSource.context = {
       dataSources: { Feature: { createScriptureFeature } },
     };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: {
         scriptureFeatures: {
           id: 123,
@@ -407,7 +422,10 @@ describe('ContentItemsModel', () => {
     dataSource.context = {
       dataSources: { Feature: { createScriptureFeature } },
     };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: {
         features: {
           id: 123,
@@ -428,7 +446,10 @@ describe('ContentItemsModel', () => {
       body: 'something',
     }));
     dataSource.context = { dataSources: { Feature: { createTextFeature } } };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: {
         textFeatures: {
           id: 123,
@@ -451,8 +472,14 @@ describe('ContentItemsModel', () => {
       body: 'something',
     }));
     dataSource.context = { dataSources: { Feature: { createTextFeature } } };
-    const result = dataSource.getFeatures({
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
+    });
+    const result = await dataSource.getFeatures({
       attributeValues: { textFeature: { id: 123, value: '' } },
+    });
+    dataSource.getCursorByChildContentItemId = () => ({
+      get: () => Promise.resolve([{ attributeValues: {}, attributes: {} }]),
     });
     expect(result).toMatchSnapshot();
     expect(createTextFeature.mock.calls).toMatchSnapshot();

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -205,8 +205,8 @@ export default class ContentItem extends RockApolloDataSource {
       );
       // If we have comments enabled on the item's parent.
     } else {
-      const parents = await await this.getCursorByChildContentItemId(
-        item.id
+      const parents = await (
+        await this.getCursorByChildContentItemId(item.id)
       ).get();
 
       if (

--- a/packages/apollos-data-connector-rock/src/content-items/data-source.js
+++ b/packages/apollos-data-connector-rock/src/content-items/data-source.js
@@ -119,7 +119,7 @@ export default class ContentItem extends RockApolloDataSource {
     }));
   };
 
-  getFeatures(item) {
+  async getFeatures(item) {
     const { attributeValues, id } = item;
     const { Feature } = this.context.dataSources;
     const features = [];
@@ -188,6 +188,7 @@ export default class ContentItem extends RockApolloDataSource {
       });
     }
 
+    // If we have comments enabled on the item itself.
     const commentFeatures = get(attributeValues, 'comments.value', 'False');
     if (commentFeatures === 'True') {
       const nodeType = item.__type || this.resolveType(item);
@@ -202,6 +203,45 @@ export default class ContentItem extends RockApolloDataSource {
         }),
         Feature.createCommentListFeature({ nodeId: id, nodeType, flagLimit })
       );
+      // If we have comments enabled on the item's parent.
+    } else {
+      const parents = await await this.getCursorByChildContentItemId(
+        item.id
+      ).get();
+
+      if (
+        parents.some(
+          (p) =>
+            get(p, 'attributeValues.childrenHaveComments.value', 'False') ===
+            'True'
+        )
+      ) {
+        const commentParent = parents.find(
+          (p) =>
+            get(p, 'attributeValues.childrenHaveComments.value', 'False') ===
+            'True'
+        );
+        const nodeType = item.__type || this.resolveType(item);
+        const flagLimit = get(ApollosConfig, 'APP.FLAG_LIMIT', 0);
+        features.push(
+          Feature.createAddCommentFeature({
+            nodeId: item.id,
+            nodeType,
+            relatedNode: item,
+            initialPrompt: this.getAddCommentInitialPrompt(
+              commentParent.attributeValues
+            ),
+            addPrompt: this.getAddCommentAddPrompt(
+              commentParent.attributeValues
+            ),
+          }),
+          Feature.createCommentListFeature({
+            nodeId: item.id,
+            nodeType,
+            flagLimit,
+          })
+        );
+      }
     }
 
     const buttonLink = attributeValues?.buttonLink?.value;


### PR DESCRIPTION
Looks at the parent content item to determine if comments should be enabled, as well as the item itself 

Code copied over from Newspring, which will be able to eliminate custom code after this is merged. 