### PR TITLE
fix: remove forced location permissions

### DIFF
--- a/packages/apollos-ui-mapview/src/utils/getUserLocation.js
+++ b/packages/apollos-ui-mapview/src/utils/getUserLocation.js
@@ -1,9 +1,5 @@
 /* eslint-disable react-native/split-platform-components */
-import {
-  PermissionsAndroid,
-  ToastAndroid,
-  Platform,
-} from 'react-native';
+import { PermissionsAndroid, ToastAndroid, Platform } from 'react-native';
 
 import Geolocation from 'react-native-geolocation-service';
 

--- a/packages/apollos-ui-mapview/src/utils/getUserLocation.js
+++ b/packages/apollos-ui-mapview/src/utils/getUserLocation.js
@@ -11,11 +11,6 @@ import Geolocation from 'react-native-geolocation-service';
 
 // Taken almost verbatum from `react-native-geolocation-service`s example app.
 const hasLocationPermissionIOS = async () => {
-  const openSetting = () => {
-    Linking.openSettings().catch(() => {
-      Alert.alert('Unable to open settings');
-    });
-  };
   const status = await Geolocation.requestAuthorization('whenInUse');
 
   if (status === 'granted') {

--- a/packages/apollos-ui-mapview/src/utils/getUserLocation.js
+++ b/packages/apollos-ui-mapview/src/utils/getUserLocation.js
@@ -1,7 +1,5 @@
 /* eslint-disable react-native/split-platform-components */
 import {
-  Alert,
-  Linking,
   PermissionsAndroid,
   ToastAndroid,
   Platform,

--- a/packages/apollos-ui-mapview/src/utils/getUserLocation.js
+++ b/packages/apollos-ui-mapview/src/utils/getUserLocation.js
@@ -22,20 +22,6 @@ const hasLocationPermissionIOS = async () => {
     return true;
   }
 
-  if (status === 'denied') {
-    Alert.alert(`Turn on Location Services to determine your location.`, '', [
-      { text: 'Go to Settings', onPress: openSetting },
-      { text: "Don't Use Location", onPress: () => {} },
-    ]);
-  }
-
-  if (status === 'disabled') {
-    Alert.alert(`Turn on Location Services to determine your location.`, '', [
-      { text: 'Go to Settings', onPress: openSetting },
-      { text: "Don't Use Location", onPress: () => {} },
-    ]);
-  }
-
   return false;
 };
 


### PR DESCRIPTION
CF got this denial on trying to ship an app update:

![image](https://user-images.githubusercontent.com/103927/119993353-16495580-bf91-11eb-95a1-2c134c1311ae.png)
> We noticed your app encourages or directs users to allow the app to access the location. Specifically, your app directs the user to grant permission in the following way(s):
> - A message asks the user to go to the Settings app and grant access after they deny permission.
Permission requests give users control of their personal information. It is important to respect their decision about how their data is used

It appears that if a user selects "No" to permissions we show an alert dialog letting them know that we won't be able to use their location. I believe simply turning these alerts to _off_ will fix this denial, and the app still fundamentally works.

@vinnyjth why did we add these alerts int he first place? do you remember what we were trying to fix?