### PR TITLE
chore: Dynamically look up Rock device mobile type ID on user registration

### DIFF
--- a/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
@@ -16,13 +16,19 @@ export default class PersonalDevices extends RockApolloDataSource {
 
     // if we already have a device, shortcut the function;
     const currentUser = await this.context.dataSources.Auth.getCurrentPerson();
+
+    
     if (existing) return currentUser;
+
+    //Get the Rock instance's personal device type value id
+    const personalDeviceTypeDefinedValue = await this.request('DefinedValues')
+    .filter(`Description eq 'Personal Device Type Mobile'`)
+    .first()
 
     await this.post('/PersonalDevices', {
       PersonAliasId: currentUser.primaryAliasId,
       DeviceRegistrationId: pushId,
-      PersonalDeviceTypeValueId:
-        ApollosConfig.ROCK_MAPPINGS.MOBILE_DEVICE_TYPE_ID || 671,
+      PersonalDeviceTypeValueId: personalDeviceTypeDefinedValue?.id || 671,
       NotificationsEnabled: 1,
       IsActive: 1,
     });

--- a/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
+++ b/packages/apollos-data-connector-rock/src/personal-devices/data-source.js
@@ -1,5 +1,4 @@
 import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
-import ApollosConfig from '@apollosproject/config';
 
 export default class PersonalDevices extends RockApolloDataSource {
   resource = 'PersonalDevices';
@@ -17,13 +16,12 @@ export default class PersonalDevices extends RockApolloDataSource {
     // if we already have a device, shortcut the function;
     const currentUser = await this.context.dataSources.Auth.getCurrentPerson();
 
-    
     if (existing) return currentUser;
 
-    //Get the Rock instance's personal device type value id
+    // Get the Rock instance's personal device type value id
     const personalDeviceTypeDefinedValue = await this.request('DefinedValues')
-    .filter(`Description eq 'Personal Device Type Mobile'`)
-    .first()
+      .filter(`Description eq 'Personal Device Type Mobile'`)
+      .first();
 
     await this.post('/PersonalDevices', {
       PersonAliasId: currentUser.primaryAliasId,


### PR DESCRIPTION
In GraphQL Playground, run 
`mutation addDevice {
  updateUserPushSettings (input: { pushProviderUserId: "arbitrary id"}) {
    id
  }
}`