### PR TITLE
fix: Close search modal when tapping on an item

### DIFF
--- a/packages/apollos-ui-connected/src/SearchScreenConnected/SearchScreenConnected.js
+++ b/packages/apollos-ui-connected/src/SearchScreenConnected/SearchScreenConnected.js
@@ -3,9 +3,13 @@ import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
+import { useNavigation } from '@react-navigation/core';
 
 import { styled } from '@apollosproject/ui-kit';
-import SearchFeedConnected, { SearchInputHeader } from '../SearchFeedConnected';
+import {
+  SearchFeedConnected,
+  SearchInputHeader,
+} from '@apollosproject/ui-connected';
 
 const SearchBackground = styled(({ theme }) => ({
   backgroundColor: theme.colors.background.paper,
@@ -17,7 +21,7 @@ const HeaderContainer = styled({
 
 const SearchContainer = styled({ height: '100%' })(View);
 
-function SearchScreenConnected(props) {
+function Search(props) {
   const [searchText, setSearchText] = useState('');
   const [isFocused, setIsFocused] = useState(true);
 
@@ -33,6 +37,17 @@ function SearchScreenConnected(props) {
     }
   }, [isFocused]);
 
+  const navigation = useNavigation();
+
+  const handleOnPressItem = ({ item }) => {
+    const id = item?.node?.id;
+    navigation.pop();
+    return navigation.navigate('ContentSingle', {
+      itemId: id,
+      transitionKey: item.transitionKey,
+    });
+  };
+
   return (
     <SearchBackground>
       <SafeAreaView edges={['right', 'left']}>
@@ -44,14 +59,17 @@ function SearchScreenConnected(props) {
           />
         </HeaderContainer>
         <SearchContainer>
-          <SearchFeedConnected searchText={searchText} />
+          <SearchFeedConnected
+            searchText={searchText}
+            onPressItem={(item) => handleOnPressItem({ item })}
+          />
         </SearchContainer>
       </SafeAreaView>
     </SearchBackground>
   );
 }
 
-SearchScreenConnected.propTypes = {
+Search.propTypes = {
   navigation: PropTypes.shape({
     getParam: PropTypes.func,
     setParams: PropTypes.func,
@@ -59,4 +77,4 @@ SearchScreenConnected.propTypes = {
   }),
 };
 
-export default SearchScreenConnected;
+export default Search;

--- a/packages/apollos-ui-connected/src/SearchScreenConnected/SearchScreenConnected.js
+++ b/packages/apollos-ui-connected/src/SearchScreenConnected/SearchScreenConnected.js
@@ -21,7 +21,7 @@ const HeaderContainer = styled({
 
 const SearchContainer = styled({ height: '100%' })(View);
 
-function Search(props) {
+function SearchScreenConnected(props) {
   const [searchText, setSearchText] = useState('');
   const [isFocused, setIsFocused] = useState(true);
 
@@ -69,7 +69,7 @@ function Search(props) {
   );
 }
 
-Search.propTypes = {
+SearchScreenConnected.propTypes = {
   navigation: PropTypes.shape({
     getParam: PropTypes.func,
     setParams: PropTypes.func,
@@ -77,4 +77,4 @@ Search.propTypes = {
   }),
 };
 
-export default Search;
+export default SearchScreenConnected;


### PR DESCRIPTION
Need to get a discussion going here. Current approach works well but is a bit of a hack. 

To test, `BRANCH=search-connected yarn app`

![2021-06-04 15 12 25](https://user-images.githubusercontent.com/1637694/120852685-871bdf00-c548-11eb-9d74-1c44f4663a35.gif)
