### PR TITLE
chore: remove custom datepicker text color

### DIFF
--- a/packages/apollos-ui-kit/src/inputs/DateInput/index.js
+++ b/packages/apollos-ui-kit/src/inputs/DateInput/index.js
@@ -16,16 +16,6 @@ const StyledChip = styled(
   { marginTop: 5 },
   'ui-kit.inputs.DateInput.StyledChip'
 )(Chip);
-const StyledDateTimePicker = withTheme(
-  ({
-    theme: {
-      colors: { text },
-    },
-  }) => ({
-    textColor: text.primary,
-  }),
-  'ui-kit.inputs.DateInput.StyledDateTimePicker'
-)(DateTimePicker);
 
 class DateInput extends PureComponent {
   static propTypes = {
@@ -83,7 +73,7 @@ class DateInput extends PureComponent {
           }
           onPress={this.handleOpen}
         />
-        <StyledDateTimePicker
+        <DateTimePicker
           // slightly higher than the max so you can adjust the day or month before the year
           date={this.props.value || this.yearsAgo(17)}
           datePickerModeAndroid={'spinner'}


### PR DESCRIPTION
Can't figure out how the background color of the box is determined but on a black ground, it looks bad. The defaults seem fine. No snaps changed. Check the core app with `yarn app`

![Group 1](https://user-images.githubusercontent.com/2659478/121219803-10395b80-c852-11eb-8e46-b4881d09f2fa.png)

