### PR TITLE
fix: properly refetch liked content list

### DIFF
--- a/packages/apollos-ui-connected/src/ConnectScreenConnected/index.js
+++ b/packages/apollos-ui-connected/src/ConnectScreenConnected/index.js
@@ -66,7 +66,7 @@ const ConnectScreenConnected = (props) => {
               followListButtonTitle={'Find People to Follow'}
             />
 
-            <HorizontalLikedContentFeedConnected />
+            <HorizontalLikedContentFeedConnected refetchRef={refetchRef} />
             {ActionTable && <ActionTable />}
             {children}
           </ScrollView>

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeedConnected.js
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeedConnected.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Query } from '@apollo/client/react/components';
+import React, { useEffect } from 'react';
+import { useQuery } from '@apollo/client';
 import PropTypes from 'prop-types';
 
 import { useNavigation } from '@react-navigation/native';
@@ -7,35 +7,35 @@ import { GET_LIKED_CONTENT } from '../LikedContentFeedConnected';
 
 import HorizontalLikedContentFeed from './HorizontalLikedContentFeed';
 
-const HorizontalLikedContentFeedConnected = ({ Component }) => {
+const HorizontalLikedContentFeedConnected = ({ Component, refetchRef }) => {
   const navigation = useNavigation();
-  return (
-    <Query
-      query={GET_LIKED_CONTENT}
-      fetchPolicy="cache-and-network"
-      variables={{ first: 3 }}
-    >
-      {({
-        loading,
-        data: { likedContent: { edges = [] } = { edges: [] } } = {},
-      }) => {
-        if (!edges.length) return null;
-        return (
-          <Component
-            id={'liked'}
-            name={'Recently Liked'}
-            content={edges.map((e) => e.node)}
-            isLoading={loading}
-            navigation={navigation}
-            loadingStateObject={{
-              title: 'Recently Liked',
-              isLoading: true,
-            }}
-          />
-        );
+
+  const {
+    loading,
+    data: { likedContent: { edges = [] } = { edges: [] } } = {},
+    refetch,
+  } = useQuery(GET_LIKED_CONTENT, {
+    fetchPolicy: 'cache-and-network',
+    variables: { first: 3 },
+  });
+
+  useEffect(() => {
+    if (refetch && refetchRef) refetchRef({ refetch, id: 'liked-list' });
+  }, [refetchRef, refetch]);
+
+  return edges.length ? (
+    <Component
+      id={'liked'}
+      name={'Recently Liked'}
+      content={edges.map((e) => e.node)}
+      isLoading={loading}
+      navigation={navigation}
+      loadingStateObject={{
+        title: 'Recently Liked',
+        isLoading: true,
       }}
-    </Query>
-  );
+    />
+  ) : null;
 };
 
 HorizontalLikedContentFeedConnected.propTypes = {
@@ -44,9 +44,7 @@ HorizontalLikedContentFeedConnected.propTypes = {
     PropTypes.func,
     PropTypes.object, // type check for React fragments
   ]),
-  navigation: PropTypes.shape({
-    navigate: PropTypes.func,
-  }),
+  refetchRef: PropTypes.func,
 };
 
 HorizontalLikedContentFeedConnected.defaultProps = {


### PR DESCRIPTION
Not really sure if this will fix anything but it's at least a step in the right direction. Currently, the liked content list isn't right on a production app. 

![IMG_00B8406DA291-1](https://user-images.githubusercontent.com/2659478/121246901-a16afb00-c86f-11eb-9867-532ac7a8785e.jpeg)


This insures that it's being refetched with the rest of it.
