### PR TITLE
fix: correctly sorts latest series children

### DIFF
--- a/packages/apollos-data-connector-rock/src/action-algorithms/index.js
+++ b/packages/apollos-data-connector-rock/src/action-algorithms/index.js
@@ -182,9 +182,9 @@ Make sure you structure your algorithm entry as \`{ type: 'CONTENT_CHANNEL', aru
       .first();
     if (!series) return [];
 
-    const cursor = (
-      await ContentItem.getCursorByParentContentItemId(series.id)
-    ).expand('ContentChannel');
+    const cursor = (await ContentItem.getCursorByParentContentItemId(series.id))
+      .expand('ContentChannel')
+      .orderBy('StartDateTime', 'desc');
     const items = limit ? await cursor.top(limit).get() : await cursor.get();
 
     return items.map((item, i) => ({


### PR DESCRIPTION
I'm ok overriding the default sort like this because the purpose of this algorithm is to pull the most recent
