### PR TITLE
fix logic for Provisional IOS notifications.

### DIFF
--- a/packages/apollos-ui-notifications/src/permissionUtils.js
+++ b/packages/apollos-ui-notifications/src/permissionUtils.js
@@ -43,9 +43,21 @@ const GET_PUSH_ID = gql`
   }
 `;
 
-const requestPermissions = (updateStatus) => {
+const requestPermissions = (
+  updateStatus,
+  { hasPrompted, hasPushPermission }
+) => {
   checkNotifications().then((checkRes) => {
+    console.log('CheckRes is: ', checkRes);
     if (checkRes.status === RESULTS.DENIED) {
+      requestNotifications(['alert', 'badge', 'sound']).then(() => {
+        updateStatus();
+      });
+    } else if (
+      checkRes.status === RESULTS.GRANTED &&
+      !hasPrompted &&
+      !hasPushPermission
+    ) {
       requestNotifications(['alert', 'badge', 'sound']).then(() => {
         updateStatus();
       });

--- a/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
+++ b/packages/apollos-ui-onboarding/src/slides/AskNotifications/AskNotificationsConnected.js
@@ -38,7 +38,10 @@ const AskNotificationsWithStatus = ({
   return (
     <Component
       isLoading={status.loading}
-      onPressButton={() => requestPermissions(status.updatePermissionStatus)}
+      onPressButton={() => requestPermissions(status.updatePermissionStatus, {
+        hasPrompted: status.hasPrompted,
+        hasPushPermission: status.hasPushPermission,
+      })}
       buttonDisabled={status.hasPushPermission}
       buttonText={getButtonText({
         hasPrompted: status.hasPrompted,


### PR DESCRIPTION
Combines the logic for IOS Permission check with the logic for checking if we have asked for permission or not. This works in my testing. If there is a case I am missing here I will gladly add it. 

Documentation from onesignal 
https://documentation.onesignal.com/docs/ios-customizations