### PR TITLE
fix: remove ability to pass slides as route params

### DIFF
--- a/packages/apollos-ui-onboarding/src/Onboarding/index.js
+++ b/packages/apollos-ui-onboarding/src/Onboarding/index.js
@@ -39,13 +39,12 @@ function Onboarding(props) {
   const navigation = useNavigation();
 
   const userVersion = route?.params?.userVersion || props?.userVersion || 0;
-  const slides = route?.params?.slides ||
-    props?.slides || [
-      FeaturesConnected,
-      LocationFinderConnected,
-      AskNotificationsConnected,
-      FollowConnected,
-    ];
+  const slides = props?.slides || [
+    FeaturesConnected,
+    LocationFinderConnected,
+    AskNotificationsConnected,
+    FollowConnected,
+  ];
   const { data } = useQuery(WITH_USER_ID, { fetchPolicy: 'network-only' });
   return (
     <>


### PR DESCRIPTION
react-navigation doesn't like it when you pass functions as params

<img width="1747" alt="Screen Shot 2021-06-24 at 9 20 53 AM" src="https://user-images.githubusercontent.com/2659478/123271770-2b050480-d4cf-11eb-869b-af1ebf509ffc.png">

