### PR TITLE
fix: Postgres Media bugfixes

### DIFF
--- a/packages/apollos-data-connector-postgres/src/media/migrations/001_create_media.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/001_create_media.js
@@ -2,12 +2,6 @@ import { DataTypes, Sequelize } from 'sequelize';
 
 async function up({ context: queryInterface }) {
   await queryInterface.createTable('media', {
-    originId: {
-      primaryKey: true,
-      type: Sequelize.STRING,
-      allowNull: false,
-    },
-    originType: { type: Sequelize.STRING, allowNull: false },
     type: DataTypes.ENUM(['IMAGE', 'VIDEO', 'AUDIO']),
     url: DataTypes.STRING,
     nodeId: DataTypes.UUID,

--- a/packages/apollos-data-connector-postgres/src/media/migrations/001_create_media.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/001_create_media.js
@@ -1,4 +1,4 @@
-import { DataTypes, Sequelize } from 'sequelize';
+import { DataTypes } from 'sequelize';
 
 async function up({ context: queryInterface }) {
   await queryInterface.createTable('media', {

--- a/packages/apollos-data-connector-postgres/src/media/migrations/002_update_media_primary_keys.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/002_update_media_primary_keys.js
@@ -20,6 +20,7 @@ async function up({ context: queryInterface }) {
 
     await queryInterface.addIndex('media', ['originId', 'originType'], {
       unique: true,
+      transaction: t,
     });
   });
 }

--- a/packages/apollos-data-connector-postgres/src/media/migrations/002_update_media_primary_keys.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/002_update_media_primary_keys.js
@@ -6,7 +6,6 @@ async function up({ context: queryInterface }) {
       'media',
       'originId',
       {
-        primaryKey: true,
         type: Sequelize.STRING,
         allowNull: false,
       },

--- a/packages/apollos-data-connector-postgres/src/media/migrations/003_add_id_to_media.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/003_add_id_to_media.js
@@ -6,6 +6,20 @@ async function up({ context: queryInterface }) {
     defaultValue: Sequelize.literal('uuid_generate_v4()'),
   });
 
+  await queryInterface.addColumn('media', 'apollosId', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  });
+  await queryInterface.addColumn('media', 'apollosType', {
+    type: Sequelize.STRING,
+    allowNull: false,
+  });
+
+  await queryInterface.addConstraint('media', {
+    fields: ['apollosId'],
+    type: 'unique',
+  });
+
   await queryInterface.addConstraint('media', {
     fields: ['id'],
     type: 'primary key',

--- a/packages/apollos-data-connector-postgres/src/media/migrations/003_add_id_to_media.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/003_add_id_to_media.js
@@ -15,6 +15,16 @@ async function up({ context: queryInterface }) {
     allowNull: false,
   });
 
+  await queryInterface.addColumn('media', 'createdAt', {
+    type: Sequelize.DATE,
+    allowNull: false,
+  });
+
+  await queryInterface.addColumn('media', 'updatedAt', {
+    type: Sequelize.DATE,
+    allowNull: false,
+  });
+
   await queryInterface.addConstraint('media', {
     fields: ['apollosId'],
     type: 'unique',
@@ -28,6 +38,10 @@ async function up({ context: queryInterface }) {
 
 async function down({ context: queryInterface }) {
   await queryInterface.removeColumn('media', 'id');
+  await queryInterface.removeColumn('apollosId', 'id');
+  await queryInterface.removeColumn('apollosType', 'id');
+  await queryInterface.removeColumn('createdAt', 'id');
+  await queryInterface.removeColumn('updatedAt', 'id');
 }
 
 const name = '003-add-id-to-media';

--- a/packages/apollos-data-connector-postgres/src/media/migrations/003_add_id_to_media.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/003_add_id_to_media.js
@@ -1,0 +1,21 @@
+import { Sequelize } from 'sequelize';
+
+async function up({ context: queryInterface }) {
+  await queryInterface.addColumn('media', 'id', {
+    type: Sequelize.UUID,
+    defaultValue: Sequelize.literal('uuid_generate_v4()'),
+  });
+
+  await queryInterface.addConstraint('media', {
+    fields: ['id'],
+    type: 'primary key',
+  });
+}
+
+async function down({ context: queryInterface }) {
+  await queryInterface.removeColumn('media', 'id');
+}
+
+const name = '003-add-id-to-media';
+
+module.exports = { up, down, name, order: 6 };

--- a/packages/apollos-data-connector-postgres/src/media/migrations/index.js
+++ b/packages/apollos-data-connector-postgres/src/media/migrations/index.js
@@ -1,6 +1,7 @@
 import CreateMedia001 from './001_create_media';
 import UpdateMediaPrimaryKeys002 from './002_update_media_primary_keys';
+import AddIdToMedia003 from './003_add_id_to_media';
 
-const migrations = [CreateMedia001, UpdateMediaPrimaryKeys002];
+const migrations = [CreateMedia001, UpdateMediaPrimaryKeys002, AddIdToMedia003];
 
 export default migrations;

--- a/packages/apollos-data-connector-postgres/src/media/model.js
+++ b/packages/apollos-data-connector-postgres/src/media/model.js
@@ -18,20 +18,22 @@ const setupModel = configureModel(({ sequelize }) => {
     sourceKey: 'id',
     constraints: false,
     scope: { nodeType: 'ContentItem', type: 'IMAGE' },
+    as: 'images',
   });
   sequelize.models.contentItem.hasMany(sequelize.models.media, {
     foreignKey: 'nodeId',
     sourceKey: 'id',
     constraints: false,
     scope: { nodeType: 'ContentItem', type: 'VIDEO' },
+    as: 'videos',
   });
   sequelize.models.contentItem.hasMany(sequelize.models.media, {
     foreignKey: 'nodeId',
     sourceKey: 'id',
     constraints: false,
     scope: { nodeType: 'ContentItem', type: 'AUDIO' },
+    as: 'audio',
   });
-  sequelize.models.media.belongsTo(sequelize.models.contentItem);
 });
 
 export { createModel, setupModel };

--- a/packages/apollos-data-connector-postgres/src/media/model.js
+++ b/packages/apollos-data-connector-postgres/src/media/model.js
@@ -31,7 +31,7 @@ const setupModel = configureModel(({ sequelize }) => {
     constraints: false,
     scope: { nodeType: 'ContentItem', type: 'AUDIO' },
   });
-  sequelize.models.media.hasOne(sequelize.models.contentItem);
+  sequelize.models.media.belongsTo(sequelize.models.contentItem);
 });
 
 export { createModel, setupModel };


### PR DESCRIPTION
1. Migration was't running because there were two primary keys (`originId` can't also be a primary key) 
2. `hasOne` expects there to be a primary key on ContentItem. I don't think we need to setup the media.contentItem relationship at this point
3. Added a few fields that were missing in the model via a migration. 