### PR TITLE
fix: Feature titles spacing

### DIFF
--- a/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/__snapshots__/ActionListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/__snapshots__/ActionListFeature.tests.js.snap
@@ -28,7 +28,6 @@ exports[`The ActionListFeatures component should render 1`] = `
       }
     }
   >
-    <View />
     <View
       cardPadding={true}
       style={
@@ -38,6 +37,17 @@ exports[`The ActionListFeatures component should render 1`] = `
         }
       }
     >
+      <View
+        style={Object {}}
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {
@@ -345,7 +355,6 @@ exports[`The ActionListFeatures component should render a button for onPressActi
       }
     }
   >
-    <View />
     <View
       cardPadding={true}
       style={
@@ -355,6 +364,17 @@ exports[`The ActionListFeatures component should render a button for onPressActi
         }
       }
     >
+      <View
+        style={Object {}}
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {
@@ -716,39 +736,6 @@ exports[`The ActionListFeatures component should render a loading state for isLo
     }
   >
     <View
-      style={
-        Object {
-          "paddingHorizontal": 16,
-          "paddingTop": 16,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 14,
-            "marginVertical": 3.5,
-            "width": "60%",
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 24,
-            "marginVertical": 1.8000000000000007,
-            "width": "100%",
-          }
-        }
-      />
-    </View>
-    <View
       cardPadding={true}
       style={
         Object {
@@ -757,6 +744,17 @@ exports[`The ActionListFeatures component should render a loading state for isLo
         }
       }
     >
+      <View
+        style={Object {}}
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {
@@ -945,27 +943,6 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
     }
   >
     <View
-      style={
-        Object {
-          "paddingHorizontal": 16,
-          "paddingTop": 16,
-        }
-      }
-    >
-      <Text
-        style={
-          Object {
-            "color": "#27272E",
-            "fontFamily": "InterUI-Black",
-            "fontSize": 24,
-            "lineHeight": 27.6,
-          }
-        }
-      >
-        This renders larger than you might expect
-      </Text>
-    </View>
-    <View
       cardPadding={true}
       style={
         Object {
@@ -974,6 +951,31 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
         }
       }
     >
+      <View
+        style={Object {}}
+      >
+        <Text
+          secondary={true}
+          style={
+            Object {
+              "color": "rgba(39, 39, 46, 0.6)",
+              "fontFamily": "InterUI-Bold",
+              "fontSize": 16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          This renders larger than you might expect
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {
@@ -1282,28 +1284,6 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
     }
   >
     <View
-      style={
-        Object {
-          "paddingHorizontal": 16,
-          "paddingTop": 16,
-        }
-      }
-    >
-      <Text
-        numberOfLines={1}
-        style={
-          Object {
-            "color": "rgba(39, 39, 46, 0.3)",
-            "fontFamily": "InterUI-Medium",
-            "fontSize": 14,
-            "lineHeight": 21,
-          }
-        }
-      >
-        This renders smaller than its name would suggest
-      </Text>
-    </View>
-    <View
       cardPadding={true}
       style={
         Object {
@@ -1312,6 +1292,31 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
         }
       }
     >
+      <View
+        style={Object {}}
+      >
+        <Text
+          primary={true}
+          style={
+            Object {
+              "color": "#27272E",
+              "fontFamily": "InterUI-Black",
+              "fontSize": 24,
+              "lineHeight": 27.6,
+            }
+          }
+        >
+          This renders smaller than its name would suggest
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {

--- a/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/__snapshots__/ActionListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/__snapshots__/ActionListFeature.tests.js.snap
@@ -37,9 +37,7 @@ exports[`The ActionListFeatures component should render 1`] = `
         }
       }
     >
-      <View
-        style={Object {}}
-      />
+      <View />
       <View
         style={
           Object {
@@ -364,9 +362,7 @@ exports[`The ActionListFeatures component should render a button for onPressActi
         }
       }
     >
-      <View
-        style={Object {}}
-      />
+      <View />
       <View
         style={
           Object {
@@ -744,9 +740,7 @@ exports[`The ActionListFeatures component should render a loading state for isLo
         }
       }
     >
-      <View
-        style={Object {}}
-      />
+      <View />
       <View
         style={
           Object {
@@ -951,9 +945,7 @@ exports[`The ActionListFeatures component should render with a subtitle 1`] = `
         }
       }
     >
-      <View
-        style={Object {}}
-      >
+      <View>
         <Text
           secondary={true}
           style={
@@ -1292,9 +1284,7 @@ exports[`The ActionListFeatures component should render with a title 1`] = `
         }
       }
     >
-      <View
-        style={Object {}}
-      >
+      <View>
         <Text
           primary={true}
           style={

--- a/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/index.js
+++ b/packages/apollos-ui-connected/src/ActionListFeatureConnected/ActionListFeature/index.js
@@ -1,34 +1,8 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
 
-import { styled, ActionList, H3, H5 } from '@apollosproject/ui-kit';
+import { FeatureTitles, ActionList, PaddedView } from '@apollosproject/ui-kit';
 import { get } from 'lodash';
-
-const Title = styled(
-  ({ theme }) => ({
-    color: theme.colors.text.tertiary,
-  }),
-  'ui-connected.ActionListFeatureConnected.ActionListFeature.Title'
-)(H5);
-
-const Subtitle = styled(
-  {},
-  'ui-connected.ActionListFeatureConnected.ActionListFeature.Subtitle'
-)(H3);
-
-const ActionListHeader = styled(
-  ({
-    theme: {
-      sizing: { baseUnit },
-    },
-  }) => ({
-    paddingHorizontal: baseUnit,
-    paddingTop: baseUnit,
-    // Padding Bottom is baked into the card content
-  }),
-  'ui-connected.ActionListFeatureConnected.ActionListFeature.ActionListHeader'
-)(View);
 
 const loadingStateArray = [
   {
@@ -110,8 +84,6 @@ const ActionListFeature = memo(
     primaryAction,
   }) => {
     const onPressActionListButton = onPressActionListButtonProp || onPressItem;
-    const HeaderWrapper =
-      isLoading || title || subtitle ? ActionListHeader : View;
 
     // Only render if loading or if you have actions
     return (
@@ -120,12 +92,14 @@ const ActionListFeature = memo(
           isLoading={isLoading}
           key={id}
           header={
-            <HeaderWrapper>
-              {isLoading || title ? ( // we check for isloading here so that they are included in the loading state
-                <Title numberOfLines={1}>{title}</Title>
-              ) : null}
-              {isLoading || subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
-            </HeaderWrapper>
+            <>
+              <FeatureTitles
+                title={title}
+                subtitle={subtitle}
+                isLoading={isLoading}
+              />
+              <PaddedView />
+            </>
           }
           actions={isLoading && !actions.length ? loadingStateObject : actions}
           onPressActionItem={onPressItem}

--- a/packages/apollos-ui-connected/src/ActionListFeatureConnected/__snapshots__/ActionListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ActionListFeatureConnected/__snapshots__/ActionListFeatureConnected.tests.js.snap
@@ -35,9 +35,7 @@ exports[`The ActionListFeatureConnected component should render 1`] = `
         }
       }
     >
-      <View
-        style={Object {}}
-      >
+      <View>
         <Text
           secondary={true}
           style={
@@ -236,9 +234,7 @@ exports[`The ActionListFeatureConnected component should render a loading state 
         }
       }
     >
-      <View
-        style={Object {}}
-      />
+      <View />
       <View
         style={
           Object {

--- a/packages/apollos-ui-connected/src/ActionListFeatureConnected/__snapshots__/ActionListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ActionListFeatureConnected/__snapshots__/ActionListFeatureConnected.tests.js.snap
@@ -27,40 +27,6 @@ exports[`The ActionListFeatureConnected component should render 1`] = `
     }
   >
     <View
-      style={
-        Object {
-          "paddingHorizontal": 16,
-          "paddingTop": 16,
-        }
-      }
-    >
-      <Text
-        numberOfLines={1}
-        style={
-          Object {
-            "color": "rgba(39, 39, 46, 0.3)",
-            "fontFamily": "InterUI-Medium",
-            "fontSize": 14,
-            "lineHeight": 21,
-          }
-        }
-      >
-        Some cool list
-      </Text>
-      <Text
-        style={
-          Object {
-            "color": "#27272E",
-            "fontFamily": "InterUI-Black",
-            "fontSize": 24,
-            "lineHeight": 27.6,
-          }
-        }
-      >
-        Check it out
-      </Text>
-    </View>
-    <View
       cardPadding={true}
       style={
         Object {
@@ -69,6 +35,44 @@ exports[`The ActionListFeatureConnected component should render 1`] = `
         }
       }
     >
+      <View
+        style={Object {}}
+      >
+        <Text
+          secondary={true}
+          style={
+            Object {
+              "color": "rgba(39, 39, 46, 0.6)",
+              "fontFamily": "InterUI-Bold",
+              "fontSize": 16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Check it out
+        </Text>
+        <Text
+          primary={true}
+          style={
+            Object {
+              "color": "#27272E",
+              "fontFamily": "InterUI-Black",
+              "fontSize": 24,
+              "lineHeight": 27.6,
+            }
+          }
+        >
+          Some cool list
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {
@@ -224,39 +228,6 @@ exports[`The ActionListFeatureConnected component should render a loading state 
     }
   >
     <View
-      style={
-        Object {
-          "paddingHorizontal": 16,
-          "paddingTop": 16,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 14,
-            "marginVertical": 3.5,
-            "width": "60%",
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 24,
-            "marginVertical": 1.8000000000000007,
-            "width": "100%",
-          }
-        }
-      />
-    </View>
-    <View
       cardPadding={true}
       style={
         Object {
@@ -265,6 +236,17 @@ exports[`The ActionListFeatureConnected component should render a loading state 
         }
       }
     >
+      <View
+        style={Object {}}
+      />
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 16,
+            "paddingVertical": 8,
+          }
+        }
+      />
       <View
         style={
           Object {

--- a/packages/apollos-ui-connected/src/CampaignItemListFeature/__snapshots__/CampaignItemListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/CampaignItemListFeature/__snapshots__/CampaignItemListFeature.tests.js.snap
@@ -314,9 +314,7 @@ exports[`The CampaignItemListFeature component should render a loading state for
         }
         vertical={false}
       >
-        <View
-          style={Object {}}
-        />
+        <View />
       </View>
     </View>
     <View
@@ -585,9 +583,7 @@ exports[`The CampaignItemListFeature component should render a section title 1`]
         }
         vertical={false}
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             primary={true}
             style={
@@ -868,9 +864,7 @@ exports[`The CampaignItemListFeature component should render with a subtitle 1`]
         }
         vertical={false}
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={

--- a/packages/apollos-ui-connected/src/CampaignItemListFeature/__snapshots__/CampaignItemListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/CampaignItemListFeature/__snapshots__/CampaignItemListFeature.tests.js.snap
@@ -1,157 +1,119 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The CampaignItemListFeature component should render 1`] = `
-<View>
-  <RCTScrollView
-    data={
-      Array [
-        Object {
-          "__typename": "CardListItem",
-          "action": "READ_CONTENT",
-          "actionIcon": null,
-          "coverImage": Array [
-            Object {
-              "uri": "https://picsum.photos/800",
-            },
-          ],
-          "hasAction": null,
-          "labelText": null,
-          "relatedNode": Object {
-            "__typename": "UniversalContentItem",
-            "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
+<RCTScrollView
+  ListHeaderComponent={null}
+  data={
+    Array [
+      Object {
+        "__typename": "CardListItem",
+        "action": "READ_CONTENT",
+        "actionIcon": null,
+        "coverImage": Array [
+          Object {
+            "uri": "https://picsum.photos/800",
           },
-          "summary": "Card summary",
-          "title": "Card Title",
+        ],
+        "hasAction": null,
+        "labelText": null,
+        "relatedNode": Object {
+          "__typename": "UniversalContentItem",
+          "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
         },
-      ]
-    }
-    disableVirtualization={false}
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={false}
-    initialNumToRender={10}
-    keyExtractor={[Function]}
-    maxToRenderPerBatch={10}
-    onContentSizeChange={[Function]}
-    onEndReachedThreshold={0.7}
-    onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    refreshing={false}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
-    windowSize={21}
-  >
-    <View>
+        "summary": "Card summary",
+        "title": "Card Title",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={0.7}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  refreshing={false}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
       <View
-        onLayout={[Function]}
-        style={null}
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "transform": Array [
-                Object {
-                  "scale": 1,
-                },
-              ],
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 16,
+              "marginHorizontal": 16,
+              "marginVertical": 12,
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
             }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
-                "marginHorizontal": 16,
-                "marginVertical": 12,
-                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-                "shadowOffset": Object {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 1,
-                "shadowRadius": 8,
+                "overflow": "hidden",
               }
             }
           >
             <View
               style={
                 Object {
-                  "borderRadius": 16,
-                  "overflow": "hidden",
+                  "backgroundColor": "rgb(249, 249, 251)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "rgb(249, 249, 251)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-              >
-                <Image
-                  blurRadius={80}
-                  fadeDuration={250}
-                  onLoad={[Function]}
-                  source={
-                    Array [
-                      Object {
-                        "cache": "force-cache",
-                        "uri": "https://picsum.photos/800",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#A5A5A5",
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-                <View
-                  material="regular"
-                  style={
-                    Object {
-                      "backgroundColor": "rgba(242, 242, 247, 0.8)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-              </View>
               <Image
+                blurRadius={80}
                 fadeDuration={250}
                 onLoad={[Function]}
                 source={
@@ -164,225 +126,20 @@ exports[`The CampaignItemListFeature component should render 1`] = `
                 }
                 style={
                   Object {
-                    "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
-                    "width": "100%",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
                   }
                 }
               />
               <View
+                material="regular"
                 style={
                   Object {
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
-                    "width": "100%",
-                  }
-                }
-              >
-                <Text
-                  numberOfLines={2}
-                  style={
-                    Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Black",
-                      "fontSize": 24,
-                      "lineHeight": 27.6,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#27272E",
-                      }
-                    }
-                  >
-                    Card Title
-                  </Text>
-                </Text>
-                <Text
-                  bold={false}
-                  italic={false}
-                  numberOfLines={3}
-                  style={
-                    Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 26,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                      }
-                    }
-                  >
-                    Card summary
-                  </Text>
-                </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                      "paddingTop": 8,
-                      "width": "100%",
-                    }
-                  }
-                />
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </RCTScrollView>
-</View>
-`;
-
-exports[`The CampaignItemListFeature component should render a loading state for isLoading 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "paddingBottom": 8,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
-      }
-    }
-    vertical={false}
-  >
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 14,
-          "marginVertical": 3.5,
-          "width": "60%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
-          "width": "100%",
-        }
-      }
-    />
-  </View>
-  <RCTScrollView
-    data={
-      Array [
-        Object {
-          "__typename": "",
-          "action": "",
-          "actionIcon": "umbrella",
-          "coverImage": Array [
-            Object {
-              "uri": "",
-            },
-          ],
-          "hasAction": true,
-          "isLoading": true,
-          "labelText": "",
-          "relatedNode": Object {
-            "__typename": "",
-            "id": "",
-          },
-          "summary": "boom",
-          "title": "",
-        },
-      ]
-    }
-    disableVirtualization={false}
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={false}
-    initialNumToRender={10}
-    keyExtractor={[Function]}
-    maxToRenderPerBatch={10}
-    onContentSizeChange={[Function]}
-    onEndReachedThreshold={0.7}
-    onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    refreshing={true}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
-    windowSize={21}
-  >
-    <View>
-      <View
-        onLayout={[Function]}
-        style={null}
-      >
-        <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "transform": Array [
-                Object {
-                  "scale": 1,
-                },
-              ],
-            }
-          }
-        >
-          <View
-            isLoading={true}
-            style={
-              Object {
-                "backgroundColor": "#FFFFFF",
-                "borderRadius": 16,
-                "marginHorizontal": 16,
-                "marginVertical": 12,
-                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-                "shadowOffset": Object {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 1,
-                "shadowRadius": 8,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "borderRadius": 16,
-                  "overflow": "hidden",
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "rgb(249, 249, 251)",
+                    "backgroundColor": "rgba(242, 242, 247, 0.8)",
                     "bottom": 0,
                     "flex": 1,
                     "height": "100%",
@@ -392,49 +149,243 @@ exports[`The CampaignItemListFeature component should render a loading state for
                     "top": 0,
                   }
                 }
+              />
+            </View>
+            <Image
+              fadeDuration={250}
+              onLoad={[Function]}
+              source={
+                Array [
+                  Object {
+                    "cache": "force-cache",
+                    "uri": "https://picsum.photos/800",
+                  },
+                ]
+              }
+              style={
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#A5A5A5",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <Text
+                numberOfLines={2}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Black",
+                    "fontSize": 24,
+                    "lineHeight": 27.6,
+                  }
+                }
               >
-                <Image
-                  blurRadius={80}
-                  fadeDuration={250}
-                  onLoad={[Function]}
-                  source={
-                    Array [
-                      Object {
-                        "cache": "force-cache",
-                        "uri": "",
-                      },
-                    ]
-                  }
+                <Text
                   style={
                     Object {
-                      "backgroundColor": "#A5A5A5",
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
+                      "color": "#27272E",
                     }
                   }
-                />
-                <View
-                  material="regular"
+                >
+                  Card Title
+                </Text>
+              </Text>
+              <Text
+                bold={false}
+                italic={false}
+                numberOfLines={3}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  }
+                }
+              >
+                <Text
                   style={
                     Object {
-                      "backgroundColor": "rgba(242, 242, 247, 0.8)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
+                      "color": "rgba(39, 39, 46, 0.6)",
                     }
                   }
-                />
-              </View>
+                >
+                  Card summary
+                </Text>
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "paddingTop": 8,
+                    "width": "100%",
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`The CampaignItemListFeature component should render a loading state for isLoading 1`] = `
+<RCTScrollView
+  ListHeaderComponent={
+    <mapProps(Component)
+      vertical={false}
+    >
+      <FeatureTitles
+        isLoading={true}
+      />
+    </mapProps(Component)>
+  }
+  data={
+    Array [
+      Object {
+        "__typename": "",
+        "action": "",
+        "actionIcon": "umbrella",
+        "coverImage": Array [
+          Object {
+            "uri": "",
+          },
+        ],
+        "hasAction": true,
+        "isLoading": true,
+        "labelText": "",
+        "relatedNode": Object {
+          "__typename": "",
+          "id": "",
+        },
+        "summary": "boom",
+        "title": "",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={0.7}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  refreshing={true}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 48,
+            "paddingVertical": 0,
+          }
+        }
+        vertical={false}
+      >
+        <View
+          style={Object {}}
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          isLoading={true}
+          style={
+            Object {
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 16,
+              "marginHorizontal": 16,
+              "marginVertical": 12,
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "borderRadius": 16,
+                "overflow": "hidden",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "rgb(249, 249, 251)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
               <Image
+                blurRadius={80}
                 fadeDuration={250}
-                isLoading={true}
                 onLoad={[Function]}
                 source={
                   Array [
@@ -446,262 +397,278 @@ exports[`The CampaignItemListFeature component should render a loading state for
                 }
                 style={
                   Object {
-                    "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
-                    "width": "100%",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+              <View
+                material="regular"
+                style={
+                  Object {
+                    "backgroundColor": "rgba(242, 242, 247, 0.8)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+            </View>
+            <Image
+              fadeDuration={250}
+              isLoading={true}
+              onLoad={[Function]}
+              source={
+                Array [
+                  Object {
+                    "cache": "force-cache",
+                    "uri": "",
+                  },
+                ]
+              }
+              style={
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#A5A5A5",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flex": null,
+                    "flexDirection": "row",
                   }
                 }
               />
               <View
                 style={
                   Object {
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
+                    "alignSelf": "stretch",
+                    "backgroundColor": "#A5A5A5",
+                    "borderRadius": 16,
+                    "height": 24,
+                    "marginVertical": 1.8000000000000007,
                     "width": "100%",
                   }
                 }
+              />
+              <Text
+                bold={false}
+                italic={false}
+                numberOfLines={3}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  }
+                }
               >
-                <View
-                  style={
-                    Object {
-                      "alignItems": "center",
-                      "flex": null,
-                      "flexDirection": "row",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "alignSelf": "stretch",
-                      "backgroundColor": "#A5A5A5",
-                      "borderRadius": 16,
-                      "height": 24,
-                      "marginVertical": 1.8000000000000007,
-                      "width": "100%",
-                    }
-                  }
-                />
                 <Text
-                  bold={false}
-                  italic={false}
-                  numberOfLines={3}
                   style={
                     Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 26,
+                      "color": "rgba(39, 39, 46, 0.6)",
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                      }
-                    }
-                  >
-                    boom
-                  </Text>
+                  boom
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                      "paddingTop": 8,
-                      "width": "100%",
-                    }
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "paddingTop": 8,
+                    "width": "100%",
                   }
-                />
-              </View>
+                }
+              />
             </View>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;
 
 exports[`The CampaignItemListFeature component should render a section title 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "paddingBottom": 8,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
-      }
-    }
-    vertical={false}
-  >
-    <Text
-      numberOfLines={1}
-      style={
-        Object {
-          "color": "rgba(39, 39, 46, 0.3)",
-          "fontFamily": "InterUI-Medium",
-          "fontSize": 14,
-          "lineHeight": 21,
-        }
-      }
+<RCTScrollView
+  ListHeaderComponent={
+    <mapProps(Component)
+      vertical={false}
     >
-      This renders smaller than its name would suggest
-    </Text>
-  </View>
-  <RCTScrollView
-    data={
-      Array [
-        Object {
-          "__typename": "CardListItem",
-          "action": "READ_CONTENT",
-          "actionIcon": null,
-          "coverImage": Array [
-            Object {
-              "uri": "https://picsum.photos/800",
-            },
-          ],
-          "hasAction": null,
-          "labelText": null,
-          "relatedNode": Object {
-            "__typename": "UniversalContentItem",
-            "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
+      <FeatureTitles
+        title="This renders smaller than its name would suggest"
+      />
+    </mapProps(Component)>
+  }
+  data={
+    Array [
+      Object {
+        "__typename": "CardListItem",
+        "action": "READ_CONTENT",
+        "actionIcon": null,
+        "coverImage": Array [
+          Object {
+            "uri": "https://picsum.photos/800",
           },
-          "summary": "Card summary",
-          "title": "Card Title",
+        ],
+        "hasAction": null,
+        "labelText": null,
+        "relatedNode": Object {
+          "__typename": "UniversalContentItem",
+          "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
         },
-      ]
-    }
-    disableVirtualization={false}
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={false}
-    initialNumToRender={10}
-    keyExtractor={[Function]}
-    maxToRenderPerBatch={10}
-    onContentSizeChange={[Function]}
-    onEndReachedThreshold={0.7}
-    onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    refreshing={false}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
-    windowSize={21}
-  >
-    <View>
+        "summary": "Card summary",
+        "title": "Card Title",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={0.7}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  refreshing={false}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+    >
       <View
-        onLayout={[Function]}
-        style={null}
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 48,
+            "paddingVertical": 0,
+          }
+        }
+        vertical={false}
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          style={Object {}}
+        >
+          <Text
+            primary={true}
+            style={
+              Object {
+                "color": "#27272E",
+                "fontFamily": "InterUI-Black",
+                "fontSize": 24,
+                "lineHeight": 27.6,
+              }
+            }
+          >
+            This renders smaller than its name would suggest
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
           style={
             Object {
-              "transform": Array [
-                Object {
-                  "scale": 1,
-                },
-              ],
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 16,
+              "marginHorizontal": 16,
+              "marginVertical": 12,
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
             }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
-                "marginHorizontal": 16,
-                "marginVertical": 12,
-                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-                "shadowOffset": Object {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 1,
-                "shadowRadius": 8,
+                "overflow": "hidden",
               }
             }
           >
             <View
               style={
                 Object {
-                  "borderRadius": 16,
-                  "overflow": "hidden",
+                  "backgroundColor": "rgb(249, 249, 251)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "rgb(249, 249, 251)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-              >
-                <Image
-                  blurRadius={80}
-                  fadeDuration={250}
-                  onLoad={[Function]}
-                  source={
-                    Array [
-                      Object {
-                        "cache": "force-cache",
-                        "uri": "https://picsum.photos/800",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#A5A5A5",
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-                <View
-                  material="regular"
-                  style={
-                    Object {
-                      "backgroundColor": "rgba(242, 242, 247, 0.8)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-              </View>
               <Image
+                blurRadius={80}
                 fadeDuration={250}
                 onLoad={[Function]}
                 source={
@@ -714,261 +681,277 @@ exports[`The CampaignItemListFeature component should render a section title 1`]
                 }
                 style={
                   Object {
-                    "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
-                    "width": "100%",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
                   }
                 }
               />
               <View
+                material="regular"
                 style={
                   Object {
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
-                    "width": "100%",
+                    "backgroundColor": "rgba(242, 242, 247, 0.8)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+            </View>
+            <Image
+              fadeDuration={250}
+              onLoad={[Function]}
+              source={
+                Array [
+                  Object {
+                    "cache": "force-cache",
+                    "uri": "https://picsum.photos/800",
+                  },
+                ]
+              }
+              style={
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#A5A5A5",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <Text
+                numberOfLines={2}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Black",
+                    "fontSize": 24,
+                    "lineHeight": 27.6,
                   }
                 }
               >
                 <Text
-                  numberOfLines={2}
                   style={
                     Object {
                       "color": "#27272E",
-                      "fontFamily": "InterUI-Black",
-                      "fontSize": 24,
-                      "lineHeight": 27.6,
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#27272E",
-                      }
-                    }
-                  >
-                    Card Title
-                  </Text>
+                  Card Title
                 </Text>
+              </Text>
+              <Text
+                bold={false}
+                italic={false}
+                numberOfLines={3}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  }
+                }
+              >
                 <Text
-                  bold={false}
-                  italic={false}
-                  numberOfLines={3}
                   style={
                     Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 26,
+                      "color": "rgba(39, 39, 46, 0.6)",
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                      }
-                    }
-                  >
-                    Card summary
-                  </Text>
+                  Card summary
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                      "paddingTop": 8,
-                      "width": "100%",
-                    }
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "paddingTop": 8,
+                    "width": "100%",
                   }
-                />
-              </View>
+                }
+              />
             </View>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;
 
 exports[`The CampaignItemListFeature component should render with a subtitle 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "paddingBottom": 8,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
-      }
-    }
-    vertical={false}
-  >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Black",
-          "fontSize": 24,
-          "lineHeight": 27.6,
-        }
-      }
+<RCTScrollView
+  ListHeaderComponent={
+    <mapProps(Component)
+      vertical={false}
     >
-      This renders larger than you might expect
-    </Text>
-  </View>
-  <RCTScrollView
-    data={
-      Array [
-        Object {
-          "__typename": "CardListItem",
-          "action": "READ_CONTENT",
-          "actionIcon": null,
-          "coverImage": Array [
-            Object {
-              "uri": "https://picsum.photos/800",
-            },
-          ],
-          "hasAction": null,
-          "labelText": null,
-          "relatedNode": Object {
-            "__typename": "UniversalContentItem",
-            "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
+      <FeatureTitles
+        subtitle="This renders larger than you might expect"
+      />
+    </mapProps(Component)>
+  }
+  data={
+    Array [
+      Object {
+        "__typename": "CardListItem",
+        "action": "READ_CONTENT",
+        "actionIcon": null,
+        "coverImage": Array [
+          Object {
+            "uri": "https://picsum.photos/800",
           },
-          "summary": "Card summary",
-          "title": "Card Title",
+        ],
+        "hasAction": null,
+        "labelText": null,
+        "relatedNode": Object {
+          "__typename": "UniversalContentItem",
+          "id": "UniversalContentItem:95ff79f60a028b1b506aaeedf8b4c6ae",
         },
-      ]
-    }
-    disableVirtualization={false}
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={false}
-    initialNumToRender={10}
-    keyExtractor={[Function]}
-    maxToRenderPerBatch={10}
-    onContentSizeChange={[Function]}
-    onEndReachedThreshold={0.7}
-    onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    refreshing={false}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
-    windowSize={21}
-  >
-    <View>
+        "summary": "Card summary",
+        "title": "Card Title",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={0.7}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  refreshing={false}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+    >
       <View
-        onLayout={[Function]}
-        style={null}
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 48,
+            "paddingVertical": 0,
+          }
+        }
+        vertical={false}
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          style={Object {}}
+        >
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            This renders larger than you might expect
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
           style={
             Object {
-              "transform": Array [
-                Object {
-                  "scale": 1,
-                },
-              ],
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 16,
+              "marginHorizontal": 16,
+              "marginVertical": 12,
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
             }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
-                "marginHorizontal": 16,
-                "marginVertical": 12,
-                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-                "shadowOffset": Object {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 1,
-                "shadowRadius": 8,
+                "overflow": "hidden",
               }
             }
           >
             <View
               style={
                 Object {
-                  "borderRadius": 16,
-                  "overflow": "hidden",
+                  "backgroundColor": "rgb(249, 249, 251)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "rgb(249, 249, 251)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-              >
-                <Image
-                  blurRadius={80}
-                  fadeDuration={250}
-                  onLoad={[Function]}
-                  source={
-                    Array [
-                      Object {
-                        "cache": "force-cache",
-                        "uri": "https://picsum.photos/800",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#A5A5A5",
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-                <View
-                  material="regular"
-                  style={
-                    Object {
-                      "backgroundColor": "rgba(242, 242, 247, 0.8)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-              </View>
               <Image
+                blurRadius={80}
                 fadeDuration={250}
                 onLoad={[Function]}
                 source={
@@ -981,81 +964,118 @@ exports[`The CampaignItemListFeature component should render with a subtitle 1`]
                 }
                 style={
                   Object {
-                    "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
-                    "width": "100%",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
                   }
                 }
               />
               <View
+                material="regular"
                 style={
                   Object {
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
-                    "width": "100%",
+                    "backgroundColor": "rgba(242, 242, 247, 0.8)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+            </View>
+            <Image
+              fadeDuration={250}
+              onLoad={[Function]}
+              source={
+                Array [
+                  Object {
+                    "cache": "force-cache",
+                    "uri": "https://picsum.photos/800",
+                  },
+                ]
+              }
+              style={
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#A5A5A5",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <Text
+                numberOfLines={2}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Black",
+                    "fontSize": 24,
+                    "lineHeight": 27.6,
                   }
                 }
               >
                 <Text
-                  numberOfLines={2}
                   style={
                     Object {
                       "color": "#27272E",
-                      "fontFamily": "InterUI-Black",
-                      "fontSize": 24,
-                      "lineHeight": 27.6,
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#27272E",
-                      }
-                    }
-                  >
-                    Card Title
-                  </Text>
+                  Card Title
                 </Text>
+              </Text>
+              <Text
+                bold={false}
+                italic={false}
+                numberOfLines={3}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  }
+                }
+              >
                 <Text
-                  bold={false}
-                  italic={false}
-                  numberOfLines={3}
                   style={
                     Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 26,
+                      "color": "rgba(39, 39, 46, 0.6)",
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                      }
-                    }
-                  >
-                    Card summary
-                  </Text>
+                  Card summary
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                      "paddingTop": 8,
-                      "width": "100%",
-                    }
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "paddingTop": 8,
+                    "width": "100%",
                   }
-                />
-              </View>
+                }
+              />
             </View>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;

--- a/packages/apollos-ui-connected/src/CampaignItemListFeature/index.js
+++ b/packages/apollos-ui-connected/src/CampaignItemListFeature/index.js
@@ -1,31 +1,17 @@
 import React, { memo } from 'react';
-import { View } from 'react-native';
 import PropTypes from 'prop-types';
 
 import {
   FeaturedCard,
   FeedView,
-  H3,
-  H5,
   PaddedView,
   styled,
   withIsLoading,
+  FeatureTitles,
 } from '@apollosproject/ui-kit';
 
 import { ContentCardComponentMapper } from '../ContentCardConnected';
 import { LiveConsumer } from '../live';
-
-const Title = styled(
-  ({ theme }) => ({
-    color: theme.colors.text.tertiary,
-  }),
-  'ui-connected.CampaignListFeature.Title'
-)(H5);
-
-const Subtitle = styled(
-  {},
-  'ui-connected.CampaignItemListFeature.Subtitle'
-)(H3);
 
 const Header = styled(
   ({ theme }) => ({
@@ -83,23 +69,24 @@ const loadingStateData = {
 const CampaignItemListFeature = memo(
   ({ cards, isLoading, listKey, onPressItem, subtitle, title }) =>
     !!(isLoading || cards.length) && (
-      <View>
-        {isLoading || title || subtitle ? ( // only display the Header if we are loading or have a title/subtitle
-          <Header vertical={false}>
-            {isLoading || title ? ( // we check for isloading here so that they are included in the loading state
-              <Title numberOfLines={1}>{title}</Title>
-            ) : null}
-            {isLoading || subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
-          </Header>
-        ) : null}
-        <FeedView
-          onPressItem={onPressItem}
-          ListItemComponent={ListItemComponent}
-          content={isLoading ? [loadingStateData] : cards}
-          isLoading={isLoading}
-          listKey={listKey}
-        />
-      </View>
+      <FeedView
+        onPressItem={onPressItem}
+        ListItemComponent={ListItemComponent}
+        ListHeaderComponent={
+          isLoading || title || subtitle ? ( // only display the Header if we are loading or have a title/subtitle
+            <Header vertical={false}>
+              <FeatureTitles
+                isLoading={isLoading}
+                subtitle={subtitle}
+                title={title}
+              />
+            </Header>
+          ) : null
+        }
+        content={isLoading ? [loadingStateData] : cards}
+        isLoading={isLoading}
+        listKey={listKey}
+      />
     )
 );
 

--- a/packages/apollos-ui-connected/src/ConnectScreenConnected/__snapshots__/ConnectScreenConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ConnectScreenConnected/__snapshots__/ConnectScreenConnected.tests.js.snap
@@ -563,9 +563,7 @@ exports[`import ConnectScreenConnected component renders ConnectScreenConnected 
                                 }
                               }
                             >
-                              <View
-                                style={Object {}}
-                              >
+                              <View>
                                 <Text
                                   secondary={true}
                                   style={
@@ -1701,9 +1699,7 @@ exports[`import ConnectScreenConnected component renders ConnectScreenConnected 
                                 }
                               }
                             >
-                              <View
-                                style={Object {}}
-                              >
+                              <View>
                                 <Text
                                   secondary={true}
                                   style={

--- a/packages/apollos-ui-connected/src/ConnectScreenConnected/__snapshots__/ConnectScreenConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/ConnectScreenConnected/__snapshots__/ConnectScreenConnected.tests.js.snap
@@ -563,18 +563,23 @@ exports[`import ConnectScreenConnected component renders ConnectScreenConnected 
                                 }
                               }
                             >
-                              <Text
-                                style={
-                                  Object {
-                                    "color": "#27272E",
-                                    "fontFamily": "InterUI-Bold",
-                                    "fontSize": 16,
-                                    "lineHeight": 24,
-                                  }
-                                }
+                              <View
+                                style={Object {}}
                               >
-                                Suggested Followers
-                              </Text>
+                                <Text
+                                  secondary={true}
+                                  style={
+                                    Object {
+                                      "color": "rgba(39, 39, 46, 0.6)",
+                                      "fontFamily": "InterUI-Bold",
+                                      "fontSize": 16,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                >
+                                  Suggested Followers
+                                </Text>
+                              </View>
                             </View>
                             <View
                               accessible={true}
@@ -1696,18 +1701,23 @@ exports[`import ConnectScreenConnected component renders ConnectScreenConnected 
                                 }
                               }
                             >
-                              <Text
-                                style={
-                                  Object {
-                                    "color": "#27272E",
-                                    "fontFamily": "InterUI-Bold",
-                                    "fontSize": 16,
-                                    "lineHeight": 24,
-                                  }
-                                }
+                              <View
+                                style={Object {}}
                               >
-                                Suggested Followers
-                              </Text>
+                                <Text
+                                  secondary={true}
+                                  style={
+                                    Object {
+                                      "color": "rgba(39, 39, 46, 0.6)",
+                                      "fontFamily": "InterUI-Bold",
+                                      "fontSize": 16,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                >
+                                  Suggested Followers
+                                </Text>
+                              </View>
                             </View>
                             <View
                               accessible={true}

--- a/packages/apollos-ui-connected/src/ContentNodeConnected/ContentNodeConnected.js
+++ b/packages/apollos-ui-connected/src/ContentNodeConnected/ContentNodeConnected.js
@@ -27,7 +27,7 @@ const ComponentPropType = PropTypes.oneOfType([
 ]);
 
 const NoImageSpacer = styled(({ theme }) => ({
-  height: theme.sizing.baseUnit * 4,
+  height: theme.sizing.baseUnit * 5,
 }))(View);
 
 const DefaultHeader = ({ node, isLoading }) => {

--- a/packages/apollos-ui-connected/src/FollowListConnected/FollowingListConnected.js
+++ b/packages/apollos-ui-connected/src/FollowListConnected/FollowingListConnected.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useQuery } from '@apollo/client';
 import PropTypes from 'prop-types';
-import { named, H4 } from '@apollosproject/ui-kit';
+import { named, FeatureTitles } from '@apollosproject/ui-kit';
 import GET_USERS_FOLLOWING from './getFollowing';
 import FollowListConnected from './FollowListConnected';
 
@@ -23,7 +23,7 @@ const FollowingListConnected = ({
 
   return (
     <Component
-      header={Header}
+      header={<Header />}
       loading={loading}
       followers={suggestedFollows}
       {...props}
@@ -48,7 +48,7 @@ FollowingListConnected.propTypes = {
 
 FollowingListConnected.defaultProps = {
   Component: FollowListConnected,
-  Header: <H4>{'Following'}</H4>,
+  Header: () => <FeatureTitles subtitle="Following" />, // eslint-disable-line react/display-name
 };
 
 FollowingListConnected.displayName = 'FollowingListConnected';

--- a/packages/apollos-ui-connected/src/FollowListConnected/RequestedFollowListConnected.js
+++ b/packages/apollos-ui-connected/src/FollowListConnected/RequestedFollowListConnected.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useQuery } from '@apollo/client';
 import PropTypes from 'prop-types';
-import { named, H4 } from '@apollosproject/ui-kit';
+import { named, FeatureTitles } from '@apollosproject/ui-kit';
 import GET_REQUESTED_FOLLOWS from './getRequestedFollows';
 import FollowListConnected from './FollowListConnected';
 
@@ -24,7 +24,7 @@ const RequestedFollowListConnected = ({
 
   return (
     <Component
-      header={Header}
+      header={<Header />}
       loading={loading}
       followers={followRequests}
       {...props}
@@ -49,7 +49,7 @@ RequestedFollowListConnected.propTypes = {
 
 RequestedFollowListConnected.defaultProps = {
   Component: FollowListConnected,
-  Header: <H4>{'Follow Requests'}</H4>,
+  Header: () => <FeatureTitles subtitle={'Follow Requests'} />, // eslint-disable-line react/display-name
 };
 
 RequestedFollowListConnected.displayName = 'SuggestedFollowListConnected';

--- a/packages/apollos-ui-connected/src/FollowListConnected/SuggestedFollowListConnected.js
+++ b/packages/apollos-ui-connected/src/FollowListConnected/SuggestedFollowListConnected.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useQuery } from '@apollo/client';
 import PropTypes from 'prop-types';
-import { named, H4 } from '@apollosproject/ui-kit';
+import { named, FeatureTitles } from '@apollosproject/ui-kit';
 import GET_SUGGESTED_FOLLOWS from './getSuggestedFollows';
 import FollowListConnected from './FollowListConnected';
 
@@ -24,7 +24,7 @@ const SuggestedFollowListConnected = ({
 
   return (
     <Component
-      header={Header}
+      header={<Header />}
       loading={loading}
       followers={suggestedFollows}
       {...props}
@@ -49,7 +49,7 @@ SuggestedFollowListConnected.propTypes = {
 
 SuggestedFollowListConnected.defaultProps = {
   Component: FollowListConnected,
-  Header: <H4>{'Suggested Followers'}</H4>,
+  Header: () => <FeatureTitles subtitle={'Suggested Followers'} />, // eslint-disable-line react/display-name
 };
 
 SuggestedFollowListConnected.displayName = 'SuggestedFollowListConnected';

--- a/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/FollowingListConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/FollowingListConnected.tests.js.snap
@@ -18,18 +18,23 @@ exports[`The FollowingListConnected component should render with data 1`] = `
       }
     }
   >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Bold",
-          "fontSize": 16,
-          "lineHeight": 24,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      Following
-    </Text>
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Following
+      </Text>
+    </View>
   </View>
   <View
     style={

--- a/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/FollowingListConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/FollowingListConnected.tests.js.snap
@@ -18,9 +18,7 @@ exports[`The FollowingListConnected component should render with data 1`] = `
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={

--- a/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/RequestedFollowListConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/RequestedFollowListConnected.tests.js.snap
@@ -18,18 +18,23 @@ exports[`The RequestedFollowListConnected component should render with data 1`] 
       }
     }
   >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Bold",
-          "fontSize": 16,
-          "lineHeight": 24,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      Follow Requests
-    </Text>
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Follow Requests
+      </Text>
+    </View>
   </View>
   <View
     style={

--- a/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/RequestedFollowListConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/RequestedFollowListConnected.tests.js.snap
@@ -18,9 +18,7 @@ exports[`The RequestedFollowListConnected component should render with data 1`] 
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={

--- a/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/SuggestedFollowListConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/SuggestedFollowListConnected.tests.js.snap
@@ -18,9 +18,7 @@ exports[`The SuggestedFollowListConnected component should render with data 1`] 
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={

--- a/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/SuggestedFollowListConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/FollowListConnected/__snapshots__/SuggestedFollowListConnected.tests.js.snap
@@ -18,18 +18,23 @@ exports[`The SuggestedFollowListConnected component should render with data 1`] 
       }
     }
   >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Bold",
-          "fontSize": 16,
-          "lineHeight": 24,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      Suggested Followers
-    </Text>
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Suggested Followers
+      </Text>
+    </View>
   </View>
   <View
     style={

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/HeroListFeature.stories.js
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/HeroListFeature.stories.js
@@ -81,6 +81,7 @@ storiesOf('ui-connected/HeroListFeature', module)
   .add('example', () => (
     <ActionListFeature
       actions={actions}
+      heroCard={actions[0]}
       title={'Title'}
       subtitle={'Subtitle'}
       onPressActionListButton={() => {}}

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/__snapshots__/HeroListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/__snapshots__/HeroListFeature.tests.js.snap
@@ -588,9 +588,7 @@ exports[`The HeroListFeatures component should render a loading state for isLoad
     }
   }
 >
-  <View
-    style={Object {}}
-  />
+  <View />
   <View
     style={
       Object {
@@ -1030,9 +1028,7 @@ exports[`The HeroListFeatures component should render with a subtitle 1`] = `
     }
   }
 >
-  <View
-    style={Object {}}
-  >
+  <View>
     <Text
       secondary={true}
       style={
@@ -1344,9 +1340,7 @@ exports[`The HeroListFeatures component should render with a title 1`] = `
     }
   }
 >
-  <View
-    style={Object {}}
-  >
+  <View>
     <Text
       primary={true}
       style={

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/__snapshots__/HeroListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/__snapshots__/HeroListFeature.tests.js.snap
@@ -579,42 +579,26 @@ exports[`The HeroListFeatures component should render a button for onPressAction
 `;
 
 exports[`The HeroListFeatures component should render a loading state for isLoading 1`] = `
-Array [
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={Object {}}
+  />
   <View
     style={
       Object {
-        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
+        "paddingVertical": 8,
       }
     }
-  >
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 14,
-          "marginVertical": 3.5,
-          "width": "60%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
-          "width": "100%",
-        }
-      }
-    />
-  </View>,
+  />
   <View
     accessible={true}
     focusable={true}
@@ -641,7 +625,8 @@ Array [
         Object {
           "backgroundColor": "#FFFFFF",
           "borderRadius": 16,
-          "marginHorizontal": 16,
+          "marginHorizontal": 0,
+          "marginTop": 0,
           "marginVertical": 12,
           "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
@@ -775,289 +760,595 @@ Array [
         </View>
       </View>
     </View>
-  </View>,
+  </View>
   <View
-    cardPadding={false}
     style={
       Object {
-        "paddingHorizontal": 16,
-        "paddingVertical": 16,
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
       }
     }
   >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
+      <View
         style={
           Object {
+            "alignSelf": "stretch",
             "backgroundColor": "#A5A5A5",
             "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
           }
         }
       />
       <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
           }
         }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
+      />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
+      <View
         style={
           Object {
+            "alignSelf": "stretch",
             "backgroundColor": "#A5A5A5",
             "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
           }
         }
       />
       <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
           }
         }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
+      />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
+      <View
         style={
           Object {
+            "alignSelf": "stretch",
             "backgroundColor": "#A5A5A5",
             "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
           }
         }
       />
       <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
           }
         }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
+      />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
+      <View
         style={
           Object {
+            "alignSelf": "stretch",
             "backgroundColor": "#A5A5A5",
             "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
           }
         }
       />
       <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
           }
         }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
+      />
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`The HeroListFeatures component should render with a subtitle 1`] = `
-Array [
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={Object {}}
+  >
+    <Text
+      secondary={true}
+      style={
+        Object {
+          "color": "rgba(39, 39, 46, 0.6)",
+          "fontFamily": "InterUI-Bold",
+          "fontSize": 16,
+          "lineHeight": 24,
+        }
+      }
+    >
+      This renders larger than you might expect
+    </Text>
+  </View>
   <View
     style={
       Object {
-        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
+        "paddingVertical": 8,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
       }
     }
   >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
+          }
+        }
+      >
+        What
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
+          }
+        }
+      >
+        What
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
+          }
+        }
+      >
+        What
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
+          }
+        }
+      >
+        What
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`The HeroListFeatures component should render with a title 1`] = `
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={Object {}}
+  >
     <Text
+      primary={true}
       style={
         Object {
           "color": "#27272E",
@@ -1067,609 +1358,292 @@ Array [
         }
       }
     >
-      This renders larger than you might expect
-    </Text>
-  </View>,
-  <View
-    cardPadding={false}
-    style={
-      Object {
-        "paddingHorizontal": 16,
-        "paddingVertical": 16,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200/200",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
-          }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
-          }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
-          }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
-          }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
-    </View>
-  </View>,
-]
-`;
-
-exports[`The HeroListFeatures component should render with a title 1`] = `
-Array [
-  <View
-    style={
-      Object {
-        "paddingBottom": 0,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
-      }
-    }
-  >
-    <Text
-      numberOfLines={1}
-      style={
-        Object {
-          "color": "rgba(39, 39, 46, 0.3)",
-          "fontFamily": "InterUI-Medium",
-          "fontSize": 14,
-          "lineHeight": 21,
-        }
-      }
-    >
       This renders smaller than its name would suggest
     </Text>
-  </View>,
+  </View>
   <View
-    cardPadding={false}
     style={
       Object {
         "paddingHorizontal": 16,
-        "paddingVertical": 16,
+        "paddingVertical": 8,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
       }
     }
   >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200/200",
-            },
-          ]
-        }
+      <Text
+        numberOfLines={1}
         style={
           Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
           }
         }
       >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
           }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
+        }
+      >
+        What
+      </Text>
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200",
-            },
-          ]
-        }
+      <Text
+        numberOfLines={1}
         style={
           Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
           }
         }
       >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
           }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
+        }
+      >
+        What
+      </Text>
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200",
-            },
-          ]
-        }
+      <Text
+        numberOfLines={1}
         style={
           Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
           }
         }
       >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
           }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
+        }
+      >
+        What
+      </Text>
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200",
-            },
-          ]
-        }
+      <Text
+        numberOfLines={1}
         style={
           Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
           }
         }
       >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
           }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
+        }
+      >
+        What
+      </Text>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/index.js
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/HeroListFeature/index.js
@@ -1,36 +1,15 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+import { StyleSheet } from 'react-native';
 import { get } from 'lodash';
 import {
   ActionList,
   DefaultCard,
-  H3,
-  H5,
   PaddedView,
-  styled,
   TouchableScale,
+  FeatureTitles,
 } from '@apollosproject/ui-kit';
 import { LiveConsumer } from '../../live';
-
-const Header = styled(
-  ({ theme }) => ({
-    paddingTop: theme.sizing.baseUnit * 3,
-    paddingBottom: 0,
-  }),
-  'ui-connected.HeroListFeatureConnected.HeroListFeature.Header'
-)(PaddedView);
-
-const Title = styled(
-  ({ theme }) => ({
-    color: theme.colors.text.tertiary,
-  }),
-  'ui-connected.HeroListFeatureConnected.HeroListFeature.Title'
-)(H5);
-
-const Subtitle = styled(
-  {},
-  'ui-connected.HeroListFeatureConnected.HeroListFeature.Subtitle'
-)(H3);
 
 const loadingStateArray = [
   {
@@ -99,13 +78,30 @@ const loadingStateArray = [
   },
 ];
 
+// we use a stylesheet instead of styled here so that we can just
+// pass DefaultCard as the HeroComponent below, and then pass style
+// into it - that way it's easier to swap out for other cards.
+const styles = StyleSheet.create({
+  heroItemComponent: {
+    marginHorizontal: 0,
+    marginTop: 0,
+  },
+});
+
 // TODO: Conrad is making this reusuable.
 const HeroItemComponent = ({ Component, ...item }) => (
   <LiveConsumer contentId={item.id}>
     {(liveStream) => {
       const isLive = !!(liveStream && liveStream.isLive);
       const labelText = isLive ? 'Live' : item.labelText;
-      return <Component isLive={isLive} {...item} labelText={labelText} />;
+      return (
+        <Component
+          isLive={isLive}
+          {...item}
+          labelText={labelText}
+          style={styles.heroItemComponent}
+        />
+      );
     }}
   </LiveConsumer>
 );
@@ -144,14 +140,14 @@ const HeroListFeature = memo(
           header={
             <>
               {isLoading || title || subtitle ? ( // only display the Header if we are loading or have a title/subtitle
-                <Header>
-                  {isLoading || title ? ( // we check for isloading here so that they are included in the loading state
-                    <Title numberOfLines={1}>{title}</Title>
-                  ) : null}
-                  {isLoading || subtitle ? (
-                    <Subtitle>{subtitle}</Subtitle>
-                  ) : null}
-                </Header>
+                <>
+                  <FeatureTitles
+                    title={title}
+                    subtitle={subtitle}
+                    isLoading={isLoading}
+                  />
+                  <PaddedView />
+                </>
               ) : null}
               {isLoading || heroCard ? (
                 <TouchableScale onPress={() => onPressHero(heroCard)}>
@@ -207,8 +203,8 @@ HeroListFeature.propTypes = {
 };
 
 HeroListFeature.defaultProps = {
-  HeroComponent: DefaultCard,
   loadingStateObject: loadingStateArray,
+  HeroComponent: DefaultCard,
 };
 
 export default HeroListFeature;

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/__snapshots__/HeroListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/__snapshots__/HeroListFeatureConnected.tests.js.snap
@@ -3,31 +3,33 @@
 exports[`The HeroListFeatureConnected component should not render without actions or hero 1`] = `null`;
 
 exports[`The HeroListFeatureConnected component should render 1`] = `
-Array [
-  <View
-    style={
-      Object {
-        "paddingBottom": 0,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
-      }
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
     }
+  }
+>
+  <View
+    style={Object {}}
   >
     <Text
-      numberOfLines={1}
+      secondary={true}
       style={
         Object {
-          "color": "rgba(39, 39, 46, 0.3)",
-          "fontFamily": "InterUI-Medium",
-          "fontSize": 14,
-          "lineHeight": 21,
+          "color": "rgba(39, 39, 46, 0.6)",
+          "fontFamily": "InterUI-Bold",
+          "fontSize": 16,
+          "lineHeight": 24,
         }
       }
     >
-      Some cool list
+      Check it out
     </Text>
     <Text
+      primary={true}
       style={
         Object {
           "color": "#27272E",
@@ -37,9 +39,17 @@ Array [
         }
       }
     >
-      Check it out
+      Some cool list
     </Text>
-  </View>,
+  </View>
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 16,
+        "paddingVertical": 8,
+      }
+    }
+  />
   <View
     accessible={true}
     focusable={true}
@@ -65,7 +75,8 @@ Array [
         Object {
           "backgroundColor": "#FFFFFF",
           "borderRadius": 16,
-          "marginHorizontal": 16,
+          "marginHorizontal": 0,
+          "marginTop": 0,
           "marginVertical": 12,
           "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
@@ -247,179 +258,153 @@ Array [
         </View>
       </View>
     </View>
-  </View>,
-  <View
-    cardPadding={false}
-    style={
-      Object {
-        "paddingHorizontal": 16,
-        "paddingVertical": 16,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "__typename": "ImageMediaSource",
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200/200",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
-          }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
-    </View>
-    <View
-      accessible={true}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "opacity": 1,
-        }
-      }
-    >
-      <View
-        bordered={true}
-        disabled={false}
-        pill={false}
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#A5A5A5",
-            "borderRadius": 16,
-            "borderWidth": 2,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "marginTop": 8,
-            "opacity": 1,
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-            "width": "100%",
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#A5A5A5",
-              "fontFamily": "InterUI-Bold",
-              "fontSize": 16,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Check this out
-        </Text>
-      </View>
-    </View>
-  </View>,
-]
-`;
-
-exports[`The HeroListFeatureConnected component should render a loading state when isLoading 1`] = `
-Array [
+  </View>
   <View
     style={
       Object {
-        "paddingBottom": 0,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
       }
     }
   >
-    <View
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "__typename": "ImageMediaSource",
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200/200",
+          },
+        ]
+      }
       style={
         Object {
-          "alignSelf": "stretch",
           "backgroundColor": "#A5A5A5",
           "borderRadius": 16,
-          "height": 14,
-          "marginVertical": 3.5,
-          "width": "60%",
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
         }
       }
     />
     <View
       style={
         Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
+          }
+        }
+      >
+        What
+      </Text>
+    </View>
+  </View>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <View
+      bordered={true}
+      disabled={false}
+      pill={false}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "borderColor": "#A5A5A5",
           "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
+          "borderWidth": 2,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "marginTop": 8,
+          "opacity": 1,
+          "overflow": "hidden",
+          "paddingHorizontal": 16,
           "width": "100%",
         }
       }
-    />
-  </View>,
+    >
+      <Text
+        style={
+          Object {
+            "color": "#A5A5A5",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Check this out
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`The HeroListFeatureConnected component should render a loading state when isLoading 1`] = `
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={Object {}}
+  />
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 16,
+        "paddingVertical": 8,
+      }
+    }
+  />
   <View
     accessible={true}
     focusable={true}
@@ -446,7 +431,8 @@ Array [
         Object {
           "backgroundColor": "#FFFFFF",
           "borderRadius": 16,
-          "marginHorizontal": 16,
+          "marginHorizontal": 0,
+          "marginTop": 0,
           "marginVertical": 12,
           "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
@@ -580,475 +566,294 @@ Array [
         </View>
       </View>
     </View>
-  </View>,
-  <View
-    cardPadding={false}
-    style={
-      Object {
-        "paddingHorizontal": 16,
-        "paddingVertical": 16,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
-        }
-      }
-    >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "cache": "force-cache",
-              "uri": "",
-            },
-          ]
-        }
-        style={
-          Object {
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 14,
-              "marginVertical": 3.5,
-              "width": "60%",
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "100%",
-            }
-          }
-        />
-      </View>
-    </View>
-  </View>,
-]
-`;
-
-exports[`The HeroListFeatureConnected component should render without a hero card 1`] = `
-Array [
+  </View>
   <View
     style={
       Object {
-        "paddingBottom": 0,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
       }
     }
   >
-    <Text
-      numberOfLines={1}
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
       style={
         Object {
-          "color": "rgba(39, 39, 46, 0.3)",
-          "fontFamily": "InterUI-Medium",
-          "fontSize": 14,
-          "lineHeight": 21,
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
         }
       }
-    >
-      Some cool list
-    </Text>
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Black",
-          "fontSize": 24,
-          "lineHeight": 27.6,
-        }
-      }
-    >
-      Check it out
-    </Text>
-  </View>,
-  <View
-    cardPadding={false}
-    style={
-      Object {
-        "paddingHorizontal": 16,
-        "paddingVertical": 16,
-      }
-    }
-  >
+    />
     <View
       style={
         Object {
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingBottom": 8,
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      <Image
-        fadeDuration={250}
-        onLoad={[Function]}
-        source={
-          Array [
-            Object {
-              "__typename": "ImageMediaSource",
-              "cache": "force-cache",
-              "uri": "https://picsum.photos/200/200",
-            },
-          ]
-        }
+      <View
         style={
           Object {
+            "alignSelf": "stretch",
             "backgroundColor": "#A5A5A5",
             "borderRadius": 16,
-            "height": 64,
-            "marginRight": 16,
-            "width": 64,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
           }
         }
       />
       <View
         style={
           Object {
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Medium",
-              "fontSize": 14,
-              "lineHeight": 21,
-            }
-          }
-        >
-          Boom
-        </Text>
-        <Text
-          bold={false}
-          ellipsizeMode="tail"
-          italic={false}
-          numberOfLines={2}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Regular",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
-        >
-          What
-        </Text>
-      </View>
-    </View>
-    <View
-      accessible={true}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "opacity": 1,
-        }
-      }
-    >
-      <View
-        bordered={true}
-        disabled={false}
-        pill={false}
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#A5A5A5",
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
             "borderRadius": 16,
-            "borderWidth": 2,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "marginTop": 8,
-            "opacity": 1,
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
+            "height": 12,
+            "marginVertical": 3,
             "width": "100%",
           }
         }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#A5A5A5",
-              "fontFamily": "InterUI-Bold",
-              "fontSize": 16,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Check this out
-        </Text>
-      </View>
+      />
     </View>
-  </View>,
-]
-`;
-
-exports[`The HeroListFeatureConnected component should render without actions 1`] = `
-Array [
+  </View>
   <View
     style={
       Object {
-        "paddingBottom": 0,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 16,
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
       }
     }
   >
-    <Text
-      numberOfLines={1}
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
       style={
         Object {
-          "color": "rgba(39, 39, 46, 0.3)",
-          "fontFamily": "InterUI-Medium",
-          "fontSize": 14,
-          "lineHeight": 21,
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
         }
       }
     >
-      Some cool list
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
+          }
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
+          }
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "cache": "force-cache",
+            "uri": "",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 14,
+            "marginVertical": 3.5,
+            "width": "60%",
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#A5A5A5",
+            "borderRadius": 16,
+            "height": 12,
+            "marginVertical": 3,
+            "width": "100%",
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`The HeroListFeatureConnected component should render without a hero card 1`] = `
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={Object {}}
+  >
+    <Text
+      secondary={true}
+      style={
+        Object {
+          "color": "rgba(39, 39, 46, 0.6)",
+          "fontFamily": "InterUI-Bold",
+          "fontSize": 16,
+          "lineHeight": 24,
+        }
+      }
+    >
+      Check it out
     </Text>
     <Text
+      primary={true}
       style={
         Object {
           "color": "#27272E",
@@ -1058,9 +863,190 @@ Array [
         }
       }
     >
+      Some cool list
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 16,
+        "paddingVertical": 8,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "paddingBottom": 8,
+      }
+    }
+  >
+    <Image
+      fadeDuration={250}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "__typename": "ImageMediaSource",
+            "cache": "force-cache",
+            "uri": "https://picsum.photos/200/200",
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#A5A5A5",
+          "borderRadius": 16,
+          "height": 64,
+          "marginRight": 16,
+          "width": 64,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Medium",
+            "fontSize": 14,
+            "lineHeight": 21,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <Text
+        bold={false}
+        ellipsizeMode="tail"
+        italic={false}
+        numberOfLines={2}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.3)",
+            "fontFamily": "InterUI-Regular",
+            "fontSize": 12,
+            "lineHeight": 18,
+          }
+        }
+      >
+        What
+      </Text>
+    </View>
+  </View>
+  <View
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+  >
+    <View
+      bordered={true}
+      disabled={false}
+      pill={false}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "borderColor": "#A5A5A5",
+          "borderRadius": 16,
+          "borderWidth": 2,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "marginTop": 8,
+          "opacity": 1,
+          "overflow": "hidden",
+          "paddingHorizontal": 16,
+          "width": "100%",
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#A5A5A5",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Check this out
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`The HeroListFeatureConnected component should render without actions 1`] = `
+<View
+  cardPadding={false}
+  style={
+    Object {
+      "paddingHorizontal": 16,
+      "paddingVertical": 16,
+    }
+  }
+>
+  <View
+    style={Object {}}
+  >
+    <Text
+      secondary={true}
+      style={
+        Object {
+          "color": "rgba(39, 39, 46, 0.6)",
+          "fontFamily": "InterUI-Bold",
+          "fontSize": 16,
+          "lineHeight": 24,
+        }
+      }
+    >
       Check it out
     </Text>
-  </View>,
+    <Text
+      primary={true}
+      style={
+        Object {
+          "color": "#27272E",
+          "fontFamily": "InterUI-Black",
+          "fontSize": 24,
+          "lineHeight": 27.6,
+        }
+      }
+    >
+      Some cool list
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 16,
+        "paddingVertical": 8,
+      }
+    }
+  />
   <View
     accessible={true}
     focusable={true}
@@ -1086,7 +1072,8 @@ Array [
         Object {
           "backgroundColor": "#FFFFFF",
           "borderRadius": 16,
-          "marginHorizontal": 16,
+          "marginHorizontal": 0,
+          "marginTop": 0,
           "marginVertical": 12,
           "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
           "shadowOffset": Object {
@@ -1268,68 +1255,58 @@ Array [
         </View>
       </View>
     </View>
-  </View>,
+  </View>
   <View
-    cardPadding={false}
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "paddingHorizontal": 16,
-        "paddingVertical": 16,
+        "opacity": 1,
       }
     }
   >
     <View
-      accessible={true}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      bordered={true}
+      disabled={false}
+      pill={false}
       style={
         Object {
+          "alignItems": "center",
+          "backgroundColor": "transparent",
+          "borderColor": "#A5A5A5",
+          "borderRadius": 16,
+          "borderWidth": 2,
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+          "marginTop": 8,
           "opacity": 1,
+          "overflow": "hidden",
+          "paddingHorizontal": 16,
+          "width": "100%",
         }
       }
     >
-      <View
-        bordered={true}
-        disabled={false}
-        pill={false}
+      <Text
         style={
           Object {
-            "alignItems": "center",
-            "backgroundColor": "transparent",
-            "borderColor": "#A5A5A5",
-            "borderRadius": 16,
-            "borderWidth": 2,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "marginTop": 8,
-            "opacity": 1,
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-            "width": "100%",
+            "color": "#A5A5A5",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
           }
         }
       >
-        <Text
-          style={
-            Object {
-              "color": "#A5A5A5",
-              "fontFamily": "InterUI-Bold",
-              "fontSize": 16,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Check this out
-        </Text>
-      </View>
+        Check this out
+      </Text>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/packages/apollos-ui-connected/src/HeroListFeatureConnected/__snapshots__/HeroListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HeroListFeatureConnected/__snapshots__/HeroListFeatureConnected.tests.js.snap
@@ -12,9 +12,7 @@ exports[`The HeroListFeatureConnected component should render 1`] = `
     }
   }
 >
-  <View
-    style={Object {}}
-  >
+  <View>
     <Text
       secondary={true}
       style={
@@ -394,9 +392,7 @@ exports[`The HeroListFeatureConnected component should render a loading state wh
     }
   }
 >
-  <View
-    style={Object {}}
-  />
+  <View />
   <View
     style={
       Object {
@@ -836,9 +832,7 @@ exports[`The HeroListFeatureConnected component should render without a hero car
     }
   }
 >
-  <View
-    style={Object {}}
-  >
+  <View>
     <Text
       secondary={true}
       style={
@@ -1009,9 +1003,7 @@ exports[`The HeroListFeatureConnected component should render without actions 1`
     }
   }
 >
-  <View
-    style={Object {}}
-  >
+  <View>
     <Text
       secondary={true}
       style={

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
@@ -120,6 +120,14 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -321,6 +329,14 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -522,6 +538,14 @@ exports[`The HorizontalCardListFeature component should render 1`] = `
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -722,45 +746,15 @@ exports[`The HorizontalCardListFeature component should render a loading state f
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingBottom": 8,
-        "paddingLeft": 16,
-        "paddingTop": 48,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 14,
-            "marginVertical": 3.5,
-            "width": "60%",
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 24,
-            "marginVertical": 1.8000000000000007,
-            "width": "100%",
-          }
-        }
-      />
-    </View>
+      style={Object {}}
+    />
     <View
       accessible={true}
       focusable={true}
@@ -784,7 +778,6 @@ exports[`The HorizontalCardListFeature component should render a loading state f
             "alignItems": "flex-end",
             "flexDirection": "row",
             "justifyContent": "flex-end",
-            "padding": 16,
           }
         }
       >
@@ -794,9 +787,9 @@ exports[`The HorizontalCardListFeature component should render a loading state f
               "alignSelf": "stretch",
               "backgroundColor": "#A5A5A5",
               "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "50%",
+              "height": 14,
+              "marginVertical": 3.5,
+              "width": "60%",
             }
           }
         />
@@ -924,6 +917,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1102,6 +1103,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1280,6 +1289,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1458,6 +1475,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1636,6 +1661,14 @@ exports[`The HorizontalCardListFeature component should render a loading state f
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1813,28 +1846,23 @@ exports[`The HorizontalCardListFeature component should render a section title 1
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingBottom": 8,
-        "paddingLeft": 16,
-        "paddingTop": 48,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
+      style={Object {}}
     >
       <Text
-        numberOfLines={1}
+        primary={true}
         style={
           Object {
-            "color": "rgba(39, 39, 46, 0.3)",
-            "fontFamily": "InterUI-Medium",
-            "fontSize": 14,
-            "lineHeight": 21,
+            "color": "#27272E",
+            "fontFamily": "InterUI-Black",
+            "fontSize": 24,
+            "lineHeight": 27.6,
           }
         }
       >
@@ -1960,6 +1988,14 @@ exports[`The HorizontalCardListFeature component should render a section title 1
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -2161,6 +2197,14 @@ exports[`The HorizontalCardListFeature component should render a section title 1
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -2362,6 +2406,14 @@ exports[`The HorizontalCardListFeature component should render a section title 1
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -2562,27 +2614,23 @@ exports[`The HorizontalCardListFeature component should render with a section su
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingBottom": 8,
-        "paddingLeft": 16,
-        "paddingTop": 48,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
+      style={Object {}}
     >
       <Text
+        secondary={true}
         style={
           Object {
-            "color": "#27272E",
-            "fontFamily": "InterUI-Black",
-            "fontSize": 24,
-            "lineHeight": 27.6,
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
           }
         }
       >
@@ -2708,6 +2756,14 @@ exports[`The HorizontalCardListFeature component should render with a section su
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -2909,6 +2965,14 @@ exports[`The HorizontalCardListFeature component should render with a section su
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -3110,6 +3174,14 @@ exports[`The HorizontalCardListFeature component should render with a section su
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/__snapshots__/HorizontalCardListFeature.tests.js.snap
@@ -752,9 +752,7 @@ exports[`The HorizontalCardListFeature component should render a loading state f
       }
     }
   >
-    <View
-      style={Object {}}
-    />
+    <View />
     <View
       accessible={true}
       focusable={true}
@@ -1852,9 +1850,7 @@ exports[`The HorizontalCardListFeature component should render a section title 1
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         primary={true}
         style={
@@ -2620,9 +2616,7 @@ exports[`The HorizontalCardListFeature component should render with a section su
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/index.js
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/HorizontalCardListFeature/index.js
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import PropTypes from 'prop-types';
 
 import {
-  H3,
+  FeatureTitles,
   H5,
   HorizontalTileFeed,
   styled,
@@ -12,30 +12,15 @@ import {
   withTheme,
   Touchable,
   ButtonLink,
-  FlexedView,
-  H6,
 } from '@apollosproject/ui-kit';
 
 import { LiveConsumer } from '../../live';
 import { HorizontalContentCardComponentMapper } from '../../HorizontalContentCardConnected';
 
-const Title = styled(
-  ({ theme }) => ({
-    color: theme.colors.text.tertiary,
-  }),
-  'ui-connected.HorizontalCardListFeatureConnected.HorizontalCardListFeature.Title'
-)(H5);
-
-const Subtitle = styled(
-  {},
-  'ui-connected.HorizontalCardListFeatureConnected.HorizontalCardListFeature.Subtitle'
-)(H3);
-
 const Header = styled(
   ({ theme }) => ({
-    paddingTop: theme.sizing.baseUnit * 3,
-    paddingBottom: theme.sizing.baseUnit * 0.5,
-    paddingLeft: theme.sizing.baseUnit,
+    paddingTop: theme.sizing.baseUnit,
+    paddingHorizontal: theme.sizing.baseUnit,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -53,13 +38,12 @@ const AndroidTouchableFix = withTheme(
 )(Touchable);
 
 const ButtonLinkSpacing = styled(
-  ({ theme }) => ({
+  {
     flexDirection: 'row', // correctly positions the loading state
     justifyContent: 'flex-end', // correctly positions the loading state
-    padding: theme.sizing.baseUnit, // UX hack to improve tapability.
     // paddingBottom: titleAndSubtitle ? theme.sizing.baseUnit / 2 : 0,
     alignItems: 'flex-end',
-  }),
+  },
   'ui-connected.HorizontalCardListFeatureConnected.HorizontalCardListFeature.ButtonLinkSpacing'
 )(View);
 
@@ -100,7 +84,10 @@ class HorizontalCardListFeature extends PureComponent {
         const isLive = !!(liveStream && liveStream.isLive);
         const labelText = isLive ? 'Live' : item.labelText;
         return (
-          <TouchableScale onPress={() => this.props.onPressItem(item)}>
+          <TouchableScale
+            hitSlop={{ bottom: 12, left: 24, right: 24, top: 16 }}
+            onPress={() => this.props.onPressItem(item)}
+          >
             <HorizontalContentCardComponentMapper
               isLive={isLive}
               {...item}
@@ -130,20 +117,19 @@ class HorizontalCardListFeature extends PureComponent {
         <View>
           {isLoading || title || subtitle || primaryAction ? (
             <Header>
-              <FlexedView>
-                {isLoading || title ? ( // we check for isloading here so that they are included in the loading state
-                  <Title numberOfLines={1}>{title}</Title>
-                ) : null}
-                {isLoading || subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
-              </FlexedView>
+              <FeatureTitles
+                title={title}
+                subtitle={subtitle}
+                isLoading={isLoading}
+              />
               {isLoading || primaryAction ? (
                 <AndroidTouchableFix
                   onPress={() => onPressAction(primaryAction)}
                 >
                   <ButtonLinkSpacing>
-                    <H6>
+                    <H5>
                       <ButtonLink>{primaryAction?.title}</ButtonLink>
-                    </H6>
+                    </H5>
                   </ButtonLinkSpacing>
                 </AndroidTouchableFix>
               ) : null}

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/__snapshots__/HorizontalCardListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/__snapshots__/HorizontalCardListFeatureConnected.tests.js.snap
@@ -16,9 +16,7 @@ exports[`The HorizontalCardListFeatureConnected component should render 1`] = `
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={
@@ -353,9 +351,7 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
       }
     }
   >
-    <View
-      style={Object {}}
-    />
+    <View />
     <View
       accessible={true}
       focusable={true}

--- a/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/__snapshots__/HorizontalCardListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalCardListFeatureConnected/__snapshots__/HorizontalCardListFeatureConnected.tests.js.snap
@@ -10,34 +10,30 @@ exports[`The HorizontalCardListFeatureConnected component should render 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingBottom": 8,
-        "paddingLeft": 16,
-        "paddingTop": 48,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
+      style={Object {}}
     >
       <Text
-        numberOfLines={1}
+        secondary={true}
         style={
           Object {
-            "color": "rgba(39, 39, 46, 0.3)",
-            "fontFamily": "InterUI-Medium",
-            "fontSize": 14,
-            "lineHeight": 21,
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
           }
         }
       >
-        Some cool list
+        Check it out
       </Text>
       <Text
+        primary={true}
         style={
           Object {
             "color": "#27272E",
@@ -47,7 +43,7 @@ exports[`The HorizontalCardListFeatureConnected component should render 1`] = `
           }
         }
       >
-        Check it out
+        Some cool list
       </Text>
     </View>
   </View>
@@ -141,6 +137,14 @@ exports[`The HorizontalCardListFeatureConnected component should render 1`] = `
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -343,45 +347,15 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingBottom": 8,
-        "paddingLeft": 16,
-        "paddingTop": 48,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 14,
-            "marginVertical": 3.5,
-            "width": "60%",
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 24,
-            "marginVertical": 1.8000000000000007,
-            "width": "100%",
-          }
-        }
-      />
-    </View>
+      style={Object {}}
+    />
     <View
       accessible={true}
       focusable={true}
@@ -405,7 +379,6 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
             "alignItems": "flex-end",
             "flexDirection": "row",
             "justifyContent": "flex-end",
-            "padding": 16,
           }
         }
       >
@@ -415,9 +388,9 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
               "alignSelf": "stretch",
               "backgroundColor": "#A5A5A5",
               "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "50%",
+              "height": 14,
+              "marginVertical": 3.5,
+              "width": "60%",
             }
           }
         />
@@ -545,6 +518,14 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -723,6 +704,14 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -901,6 +890,14 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1079,6 +1076,14 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
@@ -1257,6 +1262,14 @@ exports[`The HorizontalCardListFeatureConnected component should render a loadin
         <View
           accessible={true}
           focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 12,
+              "left": 24,
+              "right": 24,
+              "top": 16,
+            }
+          }
           onClick={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
@@ -21,9 +21,7 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={
@@ -541,9 +539,7 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/__snapshots__/HorizontalLikedContentFeed.tests.js.snap
@@ -16,26 +16,22 @@ exports[`HorizontalLikedContentFeed renders a HorizontalLikedContentFeed 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingLeft": 16,
-        "paddingTop": 8,
+        "paddingHorizontal": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flexGrow": 2,
-        }
-      }
+      style={Object {}}
     >
       <Text
+        secondary={true}
         style={
           Object {
-            "color": "#27272E",
-            "fontFamily": "InterUI-Medium",
-            "fontSize": 14,
-            "lineHeight": 21,
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
           }
         }
       >
@@ -540,31 +536,27 @@ exports[`HorizontalLikedContentFeed renders a loading state 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
         "justifyContent": "space-between",
-        "paddingLeft": 16,
-        "paddingTop": 8,
+        "paddingHorizontal": 16,
         "zIndex": 2,
       }
     }
   >
     <View
-      style={
-        Object {
-          "flexGrow": 2,
-        }
-      }
+      style={Object {}}
     >
-      <View
+      <Text
+        secondary={true}
         style={
           Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#A5A5A5",
-            "borderRadius": 16,
-            "height": 14,
-            "marginVertical": 3.5,
-            "width": "60%",
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
           }
         }
-      />
+      >
+        Liked Content
+      </Text>
     </View>
     <View
       accessible={true}

--- a/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/index.js
+++ b/packages/apollos-ui-connected/src/HorizontalLikedContentFeedConnected/HorizontalLikedContentFeed/index.js
@@ -6,7 +6,7 @@ import {
   styled,
   withTheme,
   PaddedView,
-  H5,
+  FeatureTitles,
   H6,
   HorizontalTileFeed,
   ButtonLink,
@@ -23,17 +23,9 @@ const RowHeader = styled(
     justifyContent: 'space-between',
     alignItems: 'center',
     zIndex: 2, // UX hack to improve tapability. Positions RowHeader above StyledHorizontalTileFeed
-    paddingTop: theme.sizing.baseUnit * 0.5,
-    paddingLeft: theme.sizing.baseUnit,
+    paddingHorizontal: theme.sizing.baseUnit,
   }),
   'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.RowHeader'
-)(View);
-
-const Name = styled(
-  {
-    flexGrow: 2,
-  },
-  'ui-connected.HorizontalLikedContentFeedConnected.HorizontalLikedContentFeed.Name'
 )(View);
 
 const ButtonLinkSpacing = styled(
@@ -111,9 +103,7 @@ class HorizontalLikedContentFeed extends Component {
     return (
       <PaddedView horizontal={false}>
         <RowHeader>
-          <Name>
-            <H5>{name}</H5>
-          </Name>
+          <FeatureTitles subtitle={name} />
 
           <AndroidTouchableFix
             onPress={() => {

--- a/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/__snapshots__/VerticalCardListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/__snapshots__/VerticalCardListFeature.tests.js.snap
@@ -269,37 +269,15 @@ exports[`The VerticalCardListFeature component should render a loading state for
   <View
     style={
       Object {
-        "paddingBottom": 8,
+        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
+        "paddingTop": 16,
+        "paddingVertical": 16,
       }
     }
-    vertical={false}
   >
     <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 14,
-          "marginVertical": 3.5,
-          "width": "60%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
-          "width": "100%",
-        }
-      }
+      style={Object {}}
     />
   </View>
   <RCTScrollView
@@ -2473,27 +2451,30 @@ exports[`The VerticalCardListFeature component should render a section title 1`]
   <View
     style={
       Object {
-        "paddingBottom": 8,
+        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
+        "paddingTop": 16,
+        "paddingVertical": 16,
       }
     }
-    vertical={false}
   >
-    <Text
-      numberOfLines={1}
-      style={
-        Object {
-          "color": "rgba(39, 39, 46, 0.3)",
-          "fontFamily": "InterUI-Medium",
-          "fontSize": 14,
-          "lineHeight": 21,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      This renders smaller than its name would suggest
-    </Text>
+      <Text
+        primary={true}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Black",
+            "fontSize": 24,
+            "lineHeight": 27.6,
+          }
+        }
+      >
+        This renders smaller than its name would suggest
+      </Text>
+    </View>
   </View>
   <RCTScrollView
     data={
@@ -2762,26 +2743,30 @@ exports[`The VerticalCardListFeature component should render with a subtitle 1`]
   <View
     style={
       Object {
-        "paddingBottom": 8,
+        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
+        "paddingTop": 16,
+        "paddingVertical": 16,
       }
     }
-    vertical={false}
   >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Black",
-          "fontSize": 24,
-          "lineHeight": 27.6,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      This renders larger than you might expect
-    </Text>
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        This renders larger than you might expect
+      </Text>
+    </View>
   </View>
   <RCTScrollView
     data={

--- a/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/__snapshots__/VerticalCardListFeature.tests.js.snap
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/__snapshots__/VerticalCardListFeature.tests.js.snap
@@ -276,9 +276,7 @@ exports[`The VerticalCardListFeature component should render a loading state for
       }
     }
   >
-    <View
-      style={Object {}}
-    />
+    <View />
   </View>
   <RCTScrollView
     data={
@@ -2458,9 +2456,7 @@ exports[`The VerticalCardListFeature component should render a section title 1`]
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         primary={true}
         style={
@@ -2750,9 +2746,7 @@ exports[`The VerticalCardListFeature component should render with a subtitle 1`]
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={

--- a/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/index.js
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/VerticalCardListFeature/index.js
@@ -4,62 +4,21 @@ import PropTypes from 'prop-types';
 
 import {
   FeedView,
-  H3,
-  H5,
   PaddedView,
   styled,
   withIsLoading,
+  FeatureTitles,
 } from '@apollosproject/ui-kit';
 
 import { ContentCardComponentMapper } from '../../ContentCardConnected';
 
-const Title = styled(
-  ({ theme }) => ({
-    color: theme.colors.text.tertiary,
-  }),
-  'ui-connected.VerticalCardListFeatureConnected.VerticalCardListFeature.Title'
-)(H5);
-
-const Subtitle = styled(
-  {},
-  'ui-connected.VerticalCardListFeatureConnected.VerticalCardListFeature.Subtitle'
-)(H3);
-
 const Header = styled(
   ({ theme }) => ({
-    paddingTop: theme.sizing.baseUnit * 3,
-    paddingBottom: theme.sizing.baseUnit * 0.5,
+    paddingTop: theme.sizing.baseUnit,
+    paddingBottom: 0,
   }),
   'ui-connected.VerticalCardListFeatureConnected.VerticalCardListFeature.Header'
 )(PaddedView);
-
-// const getContent = ({ cards, isLoading }) => {
-//   let content = [];
-//   if (isLoading && !cards.length) {
-//     content = [
-//       {
-//         id: 'fakeId0',
-//         isLoading: true,
-//         title: 'Test',
-//         summary: 'Boom',
-//         channelType: '',
-//         coverImage: [],
-//         parentChannel: {
-//           id: '',
-//           name: '',
-//         },
-//       },
-//     ];
-//   } else {
-//     content = cards.map((card) => ({
-//       ...card,
-//       coverImage: get(card, 'coverImage.sources', undefined),
-//       __typename: card.relatedNode.__typename,
-//     }));
-//   }
-//
-//   return content;
-// };
 
 const loadingStateData = {
   action: '',
@@ -94,11 +53,12 @@ const VerticalCardListFeature = memo(
     !!(isLoading || cards.length) && (
       <View>
         {isLoading || title || subtitle ? ( // only display the Header if we are loading or have a title/subtitle
-          <Header vertical={false}>
-            {isLoading || title ? ( // we check for isloading here so that they are included in the loading state
-              <Title numberOfLines={1}>{title}</Title>
-            ) : null}
-            {isLoading || subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
+          <Header>
+            <FeatureTitles
+              title={title}
+              subtitle={subtitle}
+              isLoading={isLoading}
+            />
           </Header>
         ) : null}
         <FeedView

--- a/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/__snapshots__/VerticalCardListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/__snapshots__/VerticalCardListFeatureConnected.tests.js.snap
@@ -16,9 +16,7 @@ exports[`The VerticalCardListFeatureConnected component should render 1`] = `
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={
@@ -393,9 +391,7 @@ exports[`The VerticalCardListFeatureConnected component should render a featured
         }
         vertical={false}
       >
-        <View
-          style={Object {}}
-        />
+        <View />
       </View>
     </View>
     <View
@@ -605,9 +601,7 @@ exports[`The VerticalCardListFeatureConnected component should render a loading 
       }
     }
   >
-    <View
-      style={Object {}}
-    />
+    <View />
   </View>
   <RCTScrollView
     data={
@@ -2848,9 +2842,7 @@ exports[`The VerticalCardListFeatureConnected component should render as a featu
         }
         vertical={false}
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={

--- a/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/__snapshots__/VerticalCardListFeatureConnected.tests.js.snap
+++ b/packages/apollos-ui-connected/src/VerticalCardListFeatureConnected/__snapshots__/VerticalCardListFeatureConnected.tests.js.snap
@@ -9,26 +9,30 @@ exports[`The VerticalCardListFeatureConnected component should render 1`] = `
   <View
     style={
       Object {
-        "paddingBottom": 8,
+        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
+        "paddingTop": 16,
+        "paddingVertical": 16,
       }
     }
-    vertical={false}
   >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Black",
-          "fontSize": 24,
-          "lineHeight": 27.6,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      Check it out
-    </Text>
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Check it out
+      </Text>
+    </View>
   </View>
   <RCTScrollView
     data={
@@ -318,197 +322,149 @@ exports[`The VerticalCardListFeatureConnected component should render 1`] = `
 `;
 
 exports[`The VerticalCardListFeatureConnected component should render a featured loading state when isLoading 1`] = `
-<View>
-  <View
-    style={
+<RCTScrollView
+  ListHeaderComponent={
+    <mapProps(Component)
+      vertical={false}
+    >
+      <FeatureTitles
+        isLoading={true}
+      />
+    </mapProps(Component)>
+  }
+  data={
+    Array [
       Object {
-        "paddingBottom": 8,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
-      }
-    }
-    vertical={false}
-  >
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 14,
-          "marginVertical": 3.5,
-          "width": "60%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
-          "width": "100%",
-        }
-      }
-    />
-  </View>
-  <RCTScrollView
-    data={
-      Array [
-        Object {
-          "__typename": "",
-          "action": "",
-          "actionIcon": "umbrella",
-          "coverImage": Array [
-            Object {
-              "uri": "",
-            },
-          ],
-          "hasAction": true,
-          "isLoading": true,
-          "labelText": "",
-          "relatedNode": Object {
-            "__typename": "",
-            "id": "",
+        "__typename": "",
+        "action": "",
+        "actionIcon": "umbrella",
+        "coverImage": Array [
+          Object {
+            "uri": "",
           },
-          "summary": "boom",
-          "title": "",
+        ],
+        "hasAction": true,
+        "isLoading": true,
+        "labelText": "",
+        "relatedNode": Object {
+          "__typename": "",
+          "id": "",
         },
-      ]
-    }
-    disableVirtualization={false}
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={false}
-    initialNumToRender={10}
-    keyExtractor={[Function]}
-    maxToRenderPerBatch={10}
-    onContentSizeChange={[Function]}
-    onEndReachedThreshold={0.7}
-    onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    refreshing={true}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
-    windowSize={21}
-  >
-    <View>
+        "summary": "boom",
+        "title": "",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={0.7}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  refreshing={true}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+    >
       <View
-        onLayout={[Function]}
-        style={null}
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 48,
+            "paddingVertical": 0,
+          }
+        }
+        vertical={false}
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          style={Object {}}
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          isLoading={true}
           style={
             Object {
-              "transform": Array [
-                Object {
-                  "scale": 1,
-                },
-              ],
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 16,
+              "marginHorizontal": 16,
+              "marginVertical": 12,
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
             }
           }
         >
           <View
-            isLoading={true}
             style={
               Object {
-                "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
-                "marginHorizontal": 16,
-                "marginVertical": 12,
-                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-                "shadowOffset": Object {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 1,
-                "shadowRadius": 8,
+                "overflow": "hidden",
               }
             }
           >
             <View
               style={
                 Object {
-                  "borderRadius": 16,
-                  "overflow": "hidden",
+                  "backgroundColor": "rgb(249, 249, 251)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "rgb(249, 249, 251)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-              >
-                <Image
-                  blurRadius={80}
-                  fadeDuration={250}
-                  onLoad={[Function]}
-                  source={
-                    Array [
-                      Object {
-                        "cache": "force-cache",
-                        "uri": "",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#A5A5A5",
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-                <View
-                  material="regular"
-                  style={
-                    Object {
-                      "backgroundColor": "rgba(242, 242, 247, 0.8)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-              </View>
               <Image
+                blurRadius={80}
                 fadeDuration={250}
-                isLoading={true}
                 onLoad={[Function]}
                 source={
                   Array [
@@ -520,83 +476,121 @@ exports[`The VerticalCardListFeatureConnected component should render a featured
                 }
                 style={
                   Object {
-                    "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
-                    "width": "100%",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+              <View
+                material="regular"
+                style={
+                  Object {
+                    "backgroundColor": "rgba(242, 242, 247, 0.8)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+            </View>
+            <Image
+              fadeDuration={250}
+              isLoading={true}
+              onLoad={[Function]}
+              source={
+                Array [
+                  Object {
+                    "cache": "force-cache",
+                    "uri": "",
+                  },
+                ]
+              }
+              style={
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#A5A5A5",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flex": null,
+                    "flexDirection": "row",
                   }
                 }
               />
               <View
                 style={
                   Object {
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
+                    "alignSelf": "stretch",
+                    "backgroundColor": "#A5A5A5",
+                    "borderRadius": 16,
+                    "height": 24,
+                    "marginVertical": 1.8000000000000007,
                     "width": "100%",
                   }
                 }
+              />
+              <Text
+                bold={false}
+                italic={false}
+                numberOfLines={3}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  }
+                }
               >
-                <View
-                  style={
-                    Object {
-                      "alignItems": "center",
-                      "flex": null,
-                      "flexDirection": "row",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "alignSelf": "stretch",
-                      "backgroundColor": "#A5A5A5",
-                      "borderRadius": 16,
-                      "height": 24,
-                      "marginVertical": 1.8000000000000007,
-                      "width": "100%",
-                    }
-                  }
-                />
                 <Text
-                  bold={false}
-                  italic={false}
-                  numberOfLines={3}
                   style={
                     Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 26,
+                      "color": "rgba(39, 39, 46, 0.6)",
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                      }
-                    }
-                  >
-                    boom
-                  </Text>
+                  boom
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                      "paddingTop": 8,
-                      "width": "100%",
-                    }
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "paddingTop": 8,
+                    "width": "100%",
                   }
-                />
-              </View>
+                }
+              />
             </View>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;
 
 exports[`The VerticalCardListFeatureConnected component should render a loading state when isLoading 1`] = `
@@ -604,37 +598,15 @@ exports[`The VerticalCardListFeatureConnected component should render a loading 
   <View
     style={
       Object {
-        "paddingBottom": 8,
+        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
+        "paddingTop": 16,
+        "paddingVertical": 16,
       }
     }
-    vertical={false}
   >
     <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 14,
-          "marginVertical": 3.5,
-          "width": "60%",
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
-          "width": "100%",
-        }
-      }
+      style={Object {}}
     />
   </View>
   <RCTScrollView
@@ -2804,183 +2776,162 @@ exports[`The VerticalCardListFeatureConnected component should render a loading 
 `;
 
 exports[`The VerticalCardListFeatureConnected component should render as a featured card 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "paddingBottom": 8,
-        "paddingHorizontal": 16,
-        "paddingTop": 48,
-        "paddingVertical": 0,
-      }
-    }
-    vertical={false}
-  >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Black",
-          "fontSize": 24,
-          "lineHeight": 27.6,
-        }
-      }
+<RCTScrollView
+  ListHeaderComponent={
+    <mapProps(Component)
+      vertical={false}
     >
-      Check it out
-    </Text>
-  </View>
-  <RCTScrollView
-    data={
-      Array [
-        Object {
-          "__typename": "UniversalContentItem",
-          "action": "READ_CONTENT",
-          "coverImage": Array [
-            Object {
-              "__typename": "ImageMediaSource",
-              "uri": "https://picsum.photos/200/200",
-            },
-          ],
-          "hasAction": false,
-          "id": "UniversalContentItem:123",
-          "labelText": "What",
-          "relatedNode": Object {
-            "__typename": "UniversalContentItem",
-            "id": "UniversalContentItem:123",
+      <FeatureTitles
+        subtitle="Check it out"
+        title=""
+      />
+    </mapProps(Component)>
+  }
+  data={
+    Array [
+      Object {
+        "__typename": "UniversalContentItem",
+        "action": "READ_CONTENT",
+        "coverImage": Array [
+          Object {
+            "__typename": "ImageMediaSource",
+            "uri": "https://picsum.photos/200/200",
           },
-          "summary": "Read",
-          "title": "Boom",
+        ],
+        "hasAction": false,
+        "id": "UniversalContentItem:123",
+        "labelText": "What",
+        "relatedNode": Object {
+          "__typename": "UniversalContentItem",
+          "id": "UniversalContentItem:123",
         },
-      ]
-    }
-    disableVirtualization={false}
-    getItem={[Function]}
-    getItemCount={[Function]}
-    horizontal={false}
-    initialNumToRender={10}
-    keyExtractor={[Function]}
-    maxToRenderPerBatch={10}
-    onContentSizeChange={[Function]}
-    onEndReachedThreshold={0.7}
-    onLayout={[Function]}
-    onMomentumScrollEnd={[Function]}
-    onScroll={[Function]}
-    onScrollBeginDrag={[Function]}
-    onScrollEndDrag={[Function]}
-    refreshing={false}
-    removeClippedSubviews={false}
-    renderItem={[Function]}
-    scrollEventThrottle={50}
-    stickyHeaderIndices={Array []}
-    updateCellsBatchingPeriod={50}
-    viewabilityConfigCallbackPairs={Array []}
-    windowSize={21}
-  >
-    <View>
+        "summary": "Read",
+        "title": "Boom",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={0.7}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  refreshing={false}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+    >
       <View
-        onLayout={[Function]}
-        style={null}
+        style={
+          Object {
+            "paddingBottom": 8,
+            "paddingHorizontal": 16,
+            "paddingTop": 48,
+            "paddingVertical": 0,
+          }
+        }
+        vertical={false}
       >
         <View
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          style={Object {}}
+        >
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Check it out
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
           style={
             Object {
-              "transform": Array [
-                Object {
-                  "scale": 1,
-                },
-              ],
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 16,
+              "marginHorizontal": 16,
+              "marginVertical": 12,
+              "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 8,
             }
           }
         >
           <View
             style={
               Object {
-                "backgroundColor": "#FFFFFF",
                 "borderRadius": 16,
-                "marginHorizontal": 16,
-                "marginVertical": 12,
-                "shadowColor": "rgba(0, 0, 0, 0.09999999999999998)",
-                "shadowOffset": Object {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 1,
-                "shadowRadius": 8,
+                "overflow": "hidden",
               }
             }
           >
             <View
               style={
                 Object {
-                  "borderRadius": 16,
-                  "overflow": "hidden",
+                  "backgroundColor": "rgb(249, 249, 251)",
+                  "bottom": 0,
+                  "flex": 1,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "rgb(249, 249, 251)",
-                    "bottom": 0,
-                    "flex": 1,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                  }
-                }
-              >
-                <Image
-                  blurRadius={80}
-                  fadeDuration={250}
-                  onLoad={[Function]}
-                  source={
-                    Array [
-                      Object {
-                        "__typename": "ImageMediaSource",
-                        "cache": "force-cache",
-                        "uri": "https://picsum.photos/200/200",
-                      },
-                    ]
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#A5A5A5",
-                      "bottom": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-                <View
-                  material="regular"
-                  style={
-                    Object {
-                      "backgroundColor": "rgba(242, 242, 247, 0.8)",
-                      "bottom": 0,
-                      "flex": 1,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                    }
-                  }
-                />
-              </View>
               <Image
+                blurRadius={80}
                 fadeDuration={250}
                 onLoad={[Function]}
                 source={
@@ -2994,103 +2945,141 @@ exports[`The VerticalCardListFeatureConnected component should render as a featu
                 }
                 style={
                   Object {
-                    "aspectRatio": 1,
                     "backgroundColor": "#A5A5A5",
-                    "width": "100%",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
                   }
                 }
               />
               <View
+                material="regular"
                 style={
                   Object {
-                    "paddingHorizontal": 16,
-                    "paddingVertical": 16,
-                    "width": "100%",
+                    "backgroundColor": "rgba(242, 242, 247, 0.8)",
+                    "bottom": 0,
+                    "flex": 1,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+            </View>
+            <Image
+              fadeDuration={250}
+              onLoad={[Function]}
+              source={
+                Array [
+                  Object {
+                    "__typename": "ImageMediaSource",
+                    "cache": "force-cache",
+                    "uri": "https://picsum.photos/200/200",
+                  },
+                ]
+              }
+              style={
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#A5A5A5",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 16,
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flex": null,
+                    "flexDirection": "row",
                   }
                 }
               >
-                <View
-                  style={
-                    Object {
-                      "alignItems": "center",
-                      "flex": null,
-                      "flexDirection": "row",
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                        "fontFamily": "InterUI-Bold",
-                        "fontSize": 16,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    What
-                  </Text>
-                </View>
                 <Text
-                  numberOfLines={2}
                   style={
                     Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Black",
-                      "fontSize": 24,
-                      "lineHeight": 27.6,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#27272E",
-                      }
-                    }
-                  >
-                    Boom
-                  </Text>
-                </Text>
-                <Text
-                  bold={false}
-                  italic={false}
-                  numberOfLines={3}
-                  style={
-                    Object {
-                      "color": "#27272E",
-                      "fontFamily": "InterUI-Regular",
+                      "color": "rgba(39, 39, 46, 0.6)",
+                      "fontFamily": "InterUI-Bold",
                       "fontSize": 16,
-                      "lineHeight": 26,
+                      "lineHeight": 24,
                     }
                   }
                 >
-                  <Text
-                    style={
-                      Object {
-                        "color": "rgba(39, 39, 46, 0.6)",
-                      }
-                    }
-                  >
-                    Read
-                  </Text>
+                  What
                 </Text>
-                <View
+              </View>
+              <Text
+                numberOfLines={2}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Black",
+                    "fontSize": 24,
+                    "lineHeight": 27.6,
+                  }
+                }
+              >
+                <Text
                   style={
                     Object {
-                      "flexDirection": "row",
-                      "justifyContent": "space-between",
-                      "paddingTop": 8,
-                      "width": "100%",
+                      "color": "#27272E",
                     }
                   }
-                />
-              </View>
+                >
+                  Boom
+                </Text>
+              </Text>
+              <Text
+                bold={false}
+                italic={false}
+                numberOfLines={3}
+                style={
+                  Object {
+                    "color": "#27272E",
+                    "fontFamily": "InterUI-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 26,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "rgba(39, 39, 46, 0.6)",
+                    }
+                  }
+                >
+                  Read
+                </Text>
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                    "paddingTop": 8,
+                    "width": "100%",
+                  }
+                }
+              />
             </View>
           </View>
         </View>
       </View>
     </View>
-  </RCTScrollView>
-</View>
+  </View>
+</RCTScrollView>
 `;

--- a/packages/apollos-ui-kit/src/ActionList/__snapshots__/ActionList.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ActionList/__snapshots__/ActionList.tests.js.snap
@@ -1267,20 +1267,6 @@ Array [
         }
       }
     >
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={3}
-        style={
-          Object {
-            "color": "#27272E",
-            "fontFamily": "InterUI-Black",
-            "fontSize": 24,
-            "lineHeight": 27.6,
-          }
-        }
-      >
-        Custom Header Element
-      </Text>
       <View
         cardPadding={true}
         style={
@@ -1290,6 +1276,20 @@ Array [
           }
         }
       >
+        <Text
+          ellipsizeMode="tail"
+          numberOfLines={3}
+          style={
+            Object {
+              "color": "#27272E",
+              "fontFamily": "InterUI-Black",
+              "fontSize": 24,
+              "lineHeight": 27.6,
+            }
+          }
+        >
+          Custom Header Element
+        </Text>
         <View
           style={
             Object {

--- a/packages/apollos-ui-kit/src/ActionList/index.js
+++ b/packages/apollos-ui-kit/src/ActionList/index.js
@@ -72,8 +72,8 @@ class ActionList extends PureComponent {
 
     return (
       <RenderAsCard>
-        {header || null}
         <Content cardPadding={this.props.isCard}>
+          {header || null}
           {actions.map((item) => (
             <ActionListItem
               {...get(item, 'relatedNode', {})}

--- a/packages/apollos-ui-kit/src/ActionListCard/__snapshots__/ActionListCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ActionListCard/__snapshots__/ActionListCard.tests.js.snap
@@ -48,7 +48,7 @@ Array [
         style={
           Object {
             "paddingHorizontal": 16,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -597,7 +597,7 @@ Array [
         style={
           Object {
             "paddingHorizontal": 16,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -1709,7 +1709,7 @@ Array [
         style={
           Object {
             "paddingHorizontal": 16,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />

--- a/packages/apollos-ui-kit/src/Card/Content.js
+++ b/packages/apollos-ui-kit/src/Card/Content.js
@@ -1,11 +1,6 @@
 import PaddedView from '../PaddedView';
 import styled from '../styled';
 
-const Content = styled(
-  ({ theme }) => ({
-    paddingVertical: theme.sizing.baseUnit,
-  }),
-  'ui-kit.Card.Content.Content'
-)(PaddedView);
+const Content = styled({}, 'ui-kit.Card.Content.Content')(PaddedView);
 
 export default Content;

--- a/packages/apollos-ui-kit/src/Card/Content.js
+++ b/packages/apollos-ui-kit/src/Card/Content.js
@@ -1,6 +1,6 @@
 import PaddedView from '../PaddedView';
 import styled from '../styled';
 
-const Content = styled({}, 'ui-kit.Card.Content.Content')(PaddedView);
+const Content = named('ui-kit.Card.Content.Content')(PaddedView);
 
 export default Content;

--- a/packages/apollos-ui-kit/src/Card/Content.js
+++ b/packages/apollos-ui-kit/src/Card/Content.js
@@ -1,5 +1,5 @@
 import PaddedView from '../PaddedView';
-import styled from '../styled';
+import { named } from '../theme';
 
 const Content = named('ui-kit.Card.Content.Content')(PaddedView);
 

--- a/packages/apollos-ui-kit/src/ContentCard/__snapshots__/ContentCard.tests.js.snap
+++ b/packages/apollos-ui-kit/src/ContentCard/__snapshots__/ContentCard.tests.js.snap
@@ -138,7 +138,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -428,7 +428,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -645,7 +645,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -935,7 +935,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -1246,7 +1246,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -1532,7 +1532,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -1785,7 +1785,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />
@@ -2032,7 +2032,7 @@ Array [
             "justifyContent": "space-between",
             "paddingHorizontal": 16,
             "paddingTop": 0,
-            "paddingVertical": 16,
+            "paddingVertical": 8,
           }
         }
       />

--- a/packages/apollos-ui-kit/src/DefaultCard/index.js
+++ b/packages/apollos-ui-kit/src/DefaultCard/index.js
@@ -58,8 +58,9 @@ const DefaultCard = withIsLoading(
     labelText,
     summary,
     isLive,
+    style,
   }) => (
-    <Card isLoading={isLoading}>
+    <Card isLoading={isLoading} style={style}>
       <BackgroundImageBlur source={coverImage} />
 
       <CoverImage source={coverImage} />
@@ -93,6 +94,7 @@ DefaultCard.propTypes = {
   LabelComponent: PropTypes.element,
   labelText: PropTypes.string,
   summary: PropTypes.string,
+  style: PropTypes.shape({}),
 };
 
 DefaultCard.displayName = 'DefaultCard';

--- a/packages/apollos-ui-kit/src/FeatureTitles/FeatureTitles.stories.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/FeatureTitles.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@apollosproject/ui-storybook';
+
+import BackgroundView from '../BackgroundView';
+import CenteredView from '../CenteredView';
+import FeatureTitles from './index';
+
+storiesOf('ui-kit/FeatureTitles', module)
+  .addDecorator((story) => (
+    <BackgroundView>
+      {/* eslint-disable-next-line react-native/no-inline-styles */}
+      <CenteredView style={{ alignItems: 'stretch' }}>{story()}</CenteredView>
+    </BackgroundView>
+  ))
+  .add('examples', () => (
+    <FeatureTitles title="Grow with God" subtitle="Today" />
+  ));

--- a/packages/apollos-ui-kit/src/FeatureTitles/FeatureTitles.stories.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/FeatureTitles.stories.js
@@ -12,6 +12,7 @@ storiesOf('ui-kit/FeatureTitles', module)
       <CenteredView style={{ alignItems: 'stretch' }}>{story()}</CenteredView>
     </BackgroundView>
   ))
-  .add('examples', () => (
+  .add('default', () => (
     <FeatureTitles title="Grow with God" subtitle="Today" />
-  ));
+  ))
+  .add('loading', () => <FeatureTitles isLoading />);

--- a/packages/apollos-ui-kit/src/FeatureTitles/FeatureTitles.tests.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/FeatureTitles.tests.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Providers from '../Providers';
+
+import FeatureTitles from '.';
+
+describe('FeatureTitles', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <Providers>
+        <FeatureTitles
+          title={
+            'Are you telling me that you built a time machine out of a DeLorean?'
+          }
+          subtitle={'Luke, I am your father'}
+        />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render loading state', () => {
+    const tree = renderer.create(
+      <Providers>
+        <FeatureTitles isLoading />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should pass style', () => {
+    const backgroundColor = { backgroundColor: 'red' };
+    const tree = renderer.create(
+      <Providers>
+        <FeatureTitles style={backgroundColor} />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/apollos-ui-kit/src/FeatureTitles/__snapshots__/FeatureTitles.tests.js.snap
+++ b/packages/apollos-ui-kit/src/FeatureTitles/__snapshots__/FeatureTitles.tests.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FeatureTitles should pass style 1`] = `
+Array [
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {},
+      ]
+    }
+  />,
+  <View
+    style={
+      Object {
+        "backgroundColor": "red",
+      }
+    }
+  />,
+]
+`;
+
+exports[`FeatureTitles should render 1`] = `
+Array [
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {},
+      ]
+    }
+  />,
+  <View>
+    <Text
+      secondary={true}
+      style={
+        Object {
+          "color": "rgba(39, 39, 46, 0.6)",
+          "fontFamily": "InterUI-Bold",
+          "fontSize": 16,
+          "lineHeight": 24,
+        }
+      }
+    >
+      Luke, I am your father
+    </Text>
+    <Text
+      primary={true}
+      style={
+        Object {
+          "color": "#27272E",
+          "fontFamily": "InterUI-Black",
+          "fontSize": 24,
+          "lineHeight": 27.6,
+        }
+      }
+    >
+      Are you telling me that you built a time machine out of a DeLorean?
+    </Text>
+  </View>,
+]
+`;
+
+exports[`FeatureTitles should render loading state 1`] = `
+Array [
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {},
+      ]
+    }
+  />,
+  <View />,
+]
+`;

--- a/packages/apollos-ui-kit/src/FeatureTitles/index.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View } from 'react-native';
+
+import { H3, H4 } from '../typography';
+import styled from '../styled';
+
+const Container = styled({}, 'ui-kit.FeatureTitles.Container')(View);
+
+const FeatureTitles = ({ title, subtitle, isLoading }) => (
+  <Container>
+    {subtitle ? (
+      <H4 secondary isLoading={isLoading && !subtitle}>
+        {subtitle}
+      </H4>
+    ) : null}
+    {title ? (
+      <H3 primary isLoading={isLoading && !title}>
+        {title}
+      </H3>
+    ) : null}
+  </Container>
+);
+
+FeatureTitles.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  isLoading: PropTypes.bool,
+};
+
+export default FeatureTitles;

--- a/packages/apollos-ui-kit/src/FeatureTitles/index.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/index.js
@@ -7,6 +7,16 @@ import styled from '../styled';
 
 const Container = styled({}, 'ui-kit.FeatureTitles.Container')(View);
 
+/**
+ * FeatureTitles
+ * Implements https://www.figma.com/file/YHJLj8pdFxWG9npF2YmB3r/UI-Kit-2.0?node-id=27%3A373
+ *
+ * Status:
+ * - [x] Title
+ * - [x] Subtitle
+ * - [x] Loading state
+ * */
+
 const FeatureTitles = ({ title, subtitle, isLoading }) => (
   <Container>
     {subtitle ? (

--- a/packages/apollos-ui-kit/src/FeatureTitles/index.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/index.js
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { H3, H4 } from '../typography';
 import styled from '../styled';
 
-const Container = styled({}, 'ui-kit.FeatureTitles.Container')(View);
+const Container = named('ui-kit.FeatureTitles.Container')(View);
 
 /**
  * FeatureTitles

--- a/packages/apollos-ui-kit/src/FeatureTitles/index.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import { H3, H4 } from '../typography';
-import styled from '../styled';
+import { named } from '../theme';
 
 const Container = named('ui-kit.FeatureTitles.Container')(View);
 
@@ -18,8 +18,8 @@ const Container = named('ui-kit.FeatureTitles.Container')(View);
  *
  * */
 
-const FeatureTitles = ({ title, subtitle, isLoading }) => (
-  <Container>
+const FeatureTitles = ({ title, subtitle, isLoading, style }) => (
+  <Container style={style}>
     {subtitle ? (
       <H4 secondary isLoading={isLoading && !subtitle}>
         {subtitle}
@@ -37,6 +37,7 @@ FeatureTitles.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
   isLoading: PropTypes.bool,
+  style: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
 };
 
 export default FeatureTitles;

--- a/packages/apollos-ui-kit/src/FeatureTitles/index.js
+++ b/packages/apollos-ui-kit/src/FeatureTitles/index.js
@@ -15,6 +15,7 @@ const Container = styled({}, 'ui-kit.FeatureTitles.Container')(View);
  * - [x] Title
  * - [x] Subtitle
  * - [x] Loading state
+ *
  * */
 
 const FeatureTitles = ({ title, subtitle, isLoading }) => (

--- a/packages/apollos-ui-kit/src/FeedView/__snapshots__/FeedView.tests.js.snap
+++ b/packages/apollos-ui-kit/src/FeedView/__snapshots__/FeedView.tests.js.snap
@@ -467,7 +467,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -729,7 +729,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -991,7 +991,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -1253,7 +1253,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -1515,7 +1515,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -1777,7 +1777,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -2039,7 +2039,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -2301,7 +2301,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -2563,7 +2563,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -2825,7 +2825,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -3671,7 +3671,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -3933,7 +3933,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -4195,7 +4195,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -4457,7 +4457,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -4719,7 +4719,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -4981,7 +4981,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -5243,7 +5243,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -5505,7 +5505,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -5767,7 +5767,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />
@@ -6029,7 +6029,7 @@ Array [
                     "justifyContent": "space-between",
                     "paddingHorizontal": 16,
                     "paddingTop": 0,
-                    "paddingVertical": 16,
+                    "paddingVertical": 8,
                   }
                 }
               />

--- a/packages/apollos-ui-kit/src/PaddedView/__snapshots__/PaddedView.tests.js.snap
+++ b/packages/apollos-ui-kit/src/PaddedView/__snapshots__/PaddedView.tests.js.snap
@@ -23,7 +23,7 @@ Array [
     style={
       Object {
         "paddingHorizontal": 16,
-        "paddingVertical": 16,
+        "paddingVertical": 8,
       }
     }
   />,

--- a/packages/apollos-ui-kit/src/PaddedView/index.js
+++ b/packages/apollos-ui-kit/src/PaddedView/index.js
@@ -3,9 +3,12 @@ import { View } from 'react-native';
 import styled from '../styled';
 
 const PaddedView = styled(
-  ({ theme, horizontal = true, vertical = true }) => ({
+  ({ theme, horizontal = true, vertical = true, children }) => ({
     paddingHorizontal: horizontal ? theme.sizing.baseUnit : 0,
     paddingVertical: vertical ? theme.sizing.baseUnit : 0,
+    ...(!children && vertical
+      ? { paddingVertical: theme.sizing.baseUnit / 2 }
+      : {}),
   }),
   'ui-kit.PaddedView'
 )(View);

--- a/packages/apollos-ui-kit/src/index.js
+++ b/packages/apollos-ui-kit/src/index.js
@@ -27,6 +27,7 @@ export ContentCard from './ContentCard';
 export ContentTitles from './ContentTitles';
 export DefaultCard from './DefaultCard';
 export FeaturedCard from './FeaturedCard';
+export FeatureTitles from './FeatureTitles';
 export FeedView from './FeedView';
 export FlexedView from './FlexedView';
 export FollowList, { FollowListItem } from './FollowList';

--- a/packages/apollos-ui-kit/src/typography/BodySmall/index.js
+++ b/packages/apollos-ui-kit/src/typography/BodySmall/index.js
@@ -4,6 +4,7 @@ import { compose, pure, setDisplayName } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const styles = styled(({ theme, bold, italic }) => {
   let fontStack = theme.typography.sans.regular.default;
@@ -26,6 +27,7 @@ const styles = styled(({ theme, bold, italic }) => {
 
 const BodySmall = compose(
   setDisplayName('BodySmall'),
+  withThemeColor,
   styles,
   withPlaceholder(Typography),
   pure

--- a/packages/apollos-ui-kit/src/typography/BodyText/index.js
+++ b/packages/apollos-ui-kit/src/typography/BodyText/index.js
@@ -4,6 +4,7 @@ import { compose, pure, setDisplayName } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const styles = styled(({ theme, bold, italic }) => {
   let fontStack = theme.typography.sans.regular.default;
@@ -26,6 +27,7 @@ const styles = styled(({ theme, bold, italic }) => {
 
 const BodyText = compose(
   setDisplayName('BodyText'),
+  withThemeColor,
   styles,
   withPlaceholder(Typography),
   pure

--- a/packages/apollos-ui-kit/src/typography/H1/H1.tests.js
+++ b/packages/apollos-ui-kit/src/typography/H1/H1.tests.js
@@ -39,6 +39,19 @@ describe('the H1 component', () => {
     );
     expect(tree).toMatchSnapshot();
   });
+  it('should render with other color states', () => {
+    const tree = renderer.create(
+      <Providers>
+        <H1 primary>H1</H1>
+        <H1 secondary>H1</H1>
+        <H1 tertiary>H1</H1>
+        <H1 quaternary>H1</H1>
+        <H1 placeholder>H1</H1>
+        <H1 action>H1</H1>
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
   it('should render a loading state with correct positioning (margins)', () => {
     const tree = renderer.create(
       <Providers>

--- a/packages/apollos-ui-kit/src/typography/H1/__snapshots__/H1.tests.js.snap
+++ b/packages/apollos-ui-kit/src/typography/H1/__snapshots__/H1.tests.js.snap
@@ -206,3 +206,103 @@ Array [
   </Text>,
 ]
 `;
+
+exports[`the H1 component should render with other color states 1`] = `
+Array [
+  <View
+    onLayout={[Function]}
+    pointerEvents="box-none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {},
+      ]
+    }
+  />,
+  <Text
+    primary={true}
+    style={
+      Object {
+        "color": "#27272E",
+        "fontFamily": "InterUI-Black",
+        "fontSize": 43,
+        "lineHeight": 49.45,
+      }
+    }
+  >
+    H1
+  </Text>,
+  <Text
+    secondary={true}
+    style={
+      Object {
+        "color": "rgba(39, 39, 46, 0.6)",
+        "fontFamily": "InterUI-Black",
+        "fontSize": 43,
+        "lineHeight": 49.45,
+      }
+    }
+  >
+    H1
+  </Text>,
+  <Text
+    style={
+      Object {
+        "color": "rgba(39, 39, 46, 0.3)",
+        "fontFamily": "InterUI-Black",
+        "fontSize": 43,
+        "lineHeight": 49.45,
+      }
+    }
+    tertiary={true}
+  >
+    H1
+  </Text>,
+  <Text
+    quaternary={true}
+    style={
+      Object {
+        "color": "rgba(39, 39, 46, 0.18)",
+        "fontFamily": "InterUI-Black",
+        "fontSize": 43,
+        "lineHeight": 49.45,
+      }
+    }
+  >
+    H1
+  </Text>,
+  <Text
+    placeholder={true}
+    style={
+      Object {
+        "color": "rgba(229, 229, 234, 0.3)",
+        "fontFamily": "InterUI-Black",
+        "fontSize": 43,
+        "lineHeight": 49.45,
+      }
+    }
+  >
+    H1
+  </Text>,
+  <Text
+    action={true}
+    style={
+      Object {
+        "color": "#17B582",
+        "fontFamily": "InterUI-Black",
+        "fontSize": 43,
+        "lineHeight": 49.45,
+      }
+    }
+  >
+    H1
+  </Text>,
+]
+`;

--- a/packages/apollos-ui-kit/src/typography/H1/index.js
+++ b/packages/apollos-ui-kit/src/typography/H1/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const H1 = compose(
   setDisplayName('ui-kit.Typography.H1'),
+  withThemeColor,
   styled(
     ({ theme, padded }) => ({
       fontSize: theme.helpers.rem(2.6875),

--- a/packages/apollos-ui-kit/src/typography/H2/index.js
+++ b/packages/apollos-ui-kit/src/typography/H2/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const H2 = compose(
   setDisplayName('ui-kit.Typography.H2'),
+  withThemeColor,
   styled(
     ({ theme, padded }) => ({
       fontSize: theme.helpers.rem(2.25),

--- a/packages/apollos-ui-kit/src/typography/H3/index.js
+++ b/packages/apollos-ui-kit/src/typography/H3/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const H3 = compose(
   setDisplayName('ui-kit.Typography.H3'),
+  withThemeColor,
   styled(
     ({ theme, padded }) => ({
       fontSize: theme.helpers.rem(1.5),

--- a/packages/apollos-ui-kit/src/typography/H4/index.js
+++ b/packages/apollos-ui-kit/src/typography/H4/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const H4 = compose(
   setDisplayName('ui-kit.Typography.H4'),
+  withThemeColor,
   styled(
     ({ theme, padded }) => ({
       fontSize: theme.helpers.rem(1),

--- a/packages/apollos-ui-kit/src/typography/H5/index.js
+++ b/packages/apollos-ui-kit/src/typography/H5/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const H5 = compose(
   setDisplayName('ui-kit.Typography.H5'),
+  withThemeColor,
   styled(
     ({ theme, padded }) => ({
       fontSize: theme.helpers.rem(0.875),

--- a/packages/apollos-ui-kit/src/typography/H6/index.js
+++ b/packages/apollos-ui-kit/src/typography/H6/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const H6 = compose(
   setDisplayName('ui-kit.Typography.H6'),
+  withThemeColor,
   styled(
     ({ theme, padded }) => ({
       fontSize: theme.helpers.rem(0.75),

--- a/packages/apollos-ui-kit/src/typography/UIText/index.js
+++ b/packages/apollos-ui-kit/src/typography/UIText/index.js
@@ -4,9 +4,11 @@ import { compose, setDisplayName, pure } from 'recompose';
 
 import styled from '../../styled';
 import { withPlaceholder, Typography } from '../../Placeholder';
+import withThemeColor from '../withThemeColor';
 
 const UIText = compose(
   setDisplayName('ui-kit.UIText'),
+  withThemeColor,
   styled(
     ({ theme, bold, italic }) => ({
       fontSize: theme.helpers.rem(0.875),

--- a/packages/apollos-ui-kit/src/typography/withThemeColor.js
+++ b/packages/apollos-ui-kit/src/typography/withThemeColor.js
@@ -1,0 +1,22 @@
+import styled from '../styled';
+
+const withThemeColor = styled(
+  ({
+    theme,
+    primary,
+    secondary,
+    tertiary,
+    quaternary,
+    placeholder,
+    action,
+  }) => ({
+    ...(action ? { color: theme.colors.text.action } : {}),
+    ...(placeholder ? { color: theme.colors.text.placeholder } : {}),
+    ...(quaternary ? { color: theme.colors.text.quaternary } : {}),
+    ...(tertiary ? { color: theme.colors.text.tertiary } : {}),
+    ...(secondary ? { color: theme.colors.text.secondary } : {}),
+    ...(primary ? { color: theme.colors.text.primary } : {}),
+  })
+);
+
+export default withThemeColor;

--- a/packages/apollos-ui-prayer/src/PrayerFeature/PrayerFeature.stories.js
+++ b/packages/apollos-ui-prayer/src/PrayerFeature/PrayerFeature.stories.js
@@ -117,14 +117,7 @@ storiesOf('ui-prayer/PrayerFeature', module)
         source: { uri: '' },
       },
     ];
-    return (
-      <PrayerFeature
-        prayers={emptyData}
-        isLoading
-        title={'Example title'}
-        isCard={false}
-      />
-    );
+    return <PrayerFeature prayers={emptyData} isLoading isCard={false} />;
   })
   .add('onPressAdd', () => (
     <PrayerFeature prayers={prayers} onPressAdd={() => {}} />

--- a/packages/apollos-ui-prayer/src/PrayerFeature/__snapshots__/PrayerFeature.tests.js.snap
+++ b/packages/apollos-ui-prayer/src/PrayerFeature/__snapshots__/PrayerFeature.tests.js.snap
@@ -52,9 +52,7 @@ Array [
           }
         }
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={
@@ -74,7 +72,6 @@ Array [
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 24,
             "paddingHorizontal": 0,
             "paddingTop": 0,
             "paddingVertical": 16,
@@ -1002,9 +999,7 @@ Array [
           }
         }
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={
@@ -1024,7 +1019,6 @@ Array [
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 24,
             "paddingHorizontal": 0,
             "paddingTop": 0,
             "paddingVertical": 16,
@@ -1787,9 +1781,7 @@ Array [
           }
         }
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={
@@ -1809,7 +1801,6 @@ Array [
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 24,
             "paddingHorizontal": 0,
             "paddingTop": 0,
             "paddingVertical": 16,
@@ -2573,9 +2564,7 @@ Array [
           }
         }
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={
@@ -2608,7 +2597,6 @@ Array [
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 24,
             "paddingHorizontal": 0,
             "paddingTop": 0,
             "paddingVertical": 16,
@@ -3346,9 +3334,7 @@ Array [
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={
@@ -3381,7 +3367,6 @@ Array [
     style={
       Object {
         "flexDirection": "row",
-        "paddingBottom": 24,
         "paddingHorizontal": 0,
         "paddingTop": 0,
         "paddingVertical": 16,
@@ -4554,9 +4539,7 @@ Array [
           }
         }
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={
@@ -4576,7 +4559,6 @@ Array [
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 24,
             "paddingHorizontal": 0,
             "paddingTop": 0,
             "paddingVertical": 16,
@@ -5339,9 +5321,7 @@ Array [
           }
         }
       >
-        <View
-          style={Object {}}
-        >
+        <View>
           <Text
             secondary={true}
             style={
@@ -5374,7 +5354,6 @@ Array [
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 24,
             "paddingHorizontal": 0,
             "paddingTop": 0,
             "paddingVertical": 16,
@@ -6112,9 +6091,7 @@ Array [
       }
     }
   >
-    <View
-      style={Object {}}
-    >
+    <View>
       <Text
         secondary={true}
         style={
@@ -6134,7 +6111,6 @@ Array [
     style={
       Object {
         "flexDirection": "row",
-        "paddingBottom": 24,
         "paddingHorizontal": 0,
         "paddingTop": 0,
         "paddingVertical": 16,

--- a/packages/apollos-ui-prayer/src/PrayerFeature/__snapshots__/PrayerFeature.tests.js.snap
+++ b/packages/apollos-ui-prayer/src/PrayerFeature/__snapshots__/PrayerFeature.tests.js.snap
@@ -45,35 +45,38 @@ Array [
       }
     >
       <View
-        isCard={true}
         style={
           Object {
-            "paddingBottom": 0,
-            "paddingHorizontal": 24,
+            "paddingHorizontal": 16,
             "paddingVertical": 16,
           }
         }
       >
-        <Text
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Black",
-              "fontSize": 24,
-              "lineHeight": 27.6,
-            }
-          }
+        <View
+          style={Object {}}
         >
-          Prayer
-        </Text>
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Prayer
+          </Text>
+        </View>
       </View>
       <View
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 32,
+            "paddingBottom": 24,
             "paddingHorizontal": 0,
-            "paddingTop": 16,
+            "paddingTop": 0,
             "paddingVertical": 16,
           }
         }
@@ -992,35 +995,38 @@ Array [
       }
     >
       <View
-        isCard={true}
         style={
           Object {
-            "paddingBottom": 0,
-            "paddingHorizontal": 24,
+            "paddingHorizontal": 16,
             "paddingVertical": 16,
           }
         }
       >
-        <Text
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Black",
-              "fontSize": 24,
-              "lineHeight": 27.6,
-            }
-          }
+        <View
+          style={Object {}}
         >
-          Prayer
-        </Text>
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Prayer
+          </Text>
+        </View>
       </View>
       <View
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 32,
+            "paddingBottom": 24,
             "paddingHorizontal": 0,
-            "paddingTop": 16,
+            "paddingTop": 0,
             "paddingVertical": 16,
           }
         }
@@ -1774,35 +1780,38 @@ Array [
       }
     >
       <View
-        isCard={true}
         style={
           Object {
-            "paddingBottom": 0,
-            "paddingHorizontal": 24,
+            "paddingHorizontal": 16,
             "paddingVertical": 16,
           }
         }
       >
-        <Text
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Black",
-              "fontSize": 24,
-              "lineHeight": 27.6,
-            }
-          }
+        <View
+          style={Object {}}
         >
-          Prayer
-        </Text>
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Prayer
+          </Text>
+        </View>
       </View>
       <View
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 32,
+            "paddingBottom": 24,
             "paddingHorizontal": 0,
-            "paddingTop": 16,
+            "paddingTop": 0,
             "paddingVertical": 16,
           }
         }
@@ -2557,47 +2566,51 @@ Array [
       }
     >
       <View
-        isCard={true}
         style={
           Object {
-            "paddingBottom": 0,
-            "paddingHorizontal": 24,
+            "paddingHorizontal": 16,
             "paddingVertical": 16,
           }
         }
       >
         <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 12,
-              "marginVertical": 3,
-              "width": "50%",
+          style={Object {}}
+        >
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
             }
-          }
-        />
-        <View
-          style={
-            Object {
-              "alignSelf": "stretch",
-              "backgroundColor": "#A5A5A5",
-              "borderRadius": 16,
-              "height": 24,
-              "marginVertical": 1.8000000000000007,
-              "width": "100%",
+          >
+            Prayer
+          </Text>
+          <Text
+            primary={true}
+            style={
+              Object {
+                "color": "#27272E",
+                "fontFamily": "InterUI-Black",
+                "fontSize": 24,
+                "lineHeight": 27.6,
+              }
             }
-          }
-        />
+          >
+            Example title
+          </Text>
+        </View>
       </View>
       <View
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 32,
+            "paddingBottom": 24,
             "paddingHorizontal": 0,
-            "paddingTop": 16,
+            "paddingTop": 0,
             "paddingVertical": 16,
           }
         }
@@ -3326,48 +3339,51 @@ Array [
     }
   />,
   <View
-    isCard={false}
     style={
       Object {
-        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
         "paddingVertical": 16,
       }
     }
   >
     <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 12,
-          "marginVertical": 3,
-          "width": "50%",
+      style={Object {}}
+    >
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
         }
-      }
-    />
-    <View
-      style={
-        Object {
-          "alignSelf": "stretch",
-          "backgroundColor": "#A5A5A5",
-          "borderRadius": 16,
-          "height": 24,
-          "marginVertical": 1.8000000000000007,
-          "width": "100%",
+      >
+        Prayer
+      </Text>
+      <Text
+        primary={true}
+        style={
+          Object {
+            "color": "#27272E",
+            "fontFamily": "InterUI-Black",
+            "fontSize": 24,
+            "lineHeight": 27.6,
+          }
         }
-      }
-    />
+      >
+        Example title
+      </Text>
+    </View>
   </View>,
   <View
     style={
       Object {
         "flexDirection": "row",
-        "paddingBottom": 32,
+        "paddingBottom": 24,
         "paddingHorizontal": 0,
-        "paddingTop": 16,
+        "paddingTop": 0,
         "paddingVertical": 16,
       }
     }
@@ -4531,35 +4547,38 @@ Array [
       }
     >
       <View
-        isCard={true}
         style={
           Object {
-            "paddingBottom": 0,
-            "paddingHorizontal": 24,
+            "paddingHorizontal": 16,
             "paddingVertical": 16,
           }
         }
       >
-        <Text
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Black",
-              "fontSize": 24,
-              "lineHeight": 27.6,
-            }
-          }
+        <View
+          style={Object {}}
         >
-          Custom subtitle
-        </Text>
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Custom subtitle
+          </Text>
+        </View>
       </View>
       <View
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 32,
+            "paddingBottom": 24,
             "paddingHorizontal": 0,
-            "paddingTop": 16,
+            "paddingTop": 0,
             "paddingVertical": 16,
           }
         }
@@ -5313,48 +5332,51 @@ Array [
       }
     >
       <View
-        isCard={true}
         style={
           Object {
-            "paddingBottom": 0,
-            "paddingHorizontal": 24,
+            "paddingHorizontal": 16,
             "paddingVertical": 16,
           }
         }
       >
-        <Text
-          numberOfLines={1}
-          style={
-            Object {
-              "color": "rgba(39, 39, 46, 0.3)",
-              "fontFamily": "InterUI-Bold",
-              "fontSize": 12,
-              "lineHeight": 18,
-            }
-          }
+        <View
+          style={Object {}}
         >
-          Example title
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#27272E",
-              "fontFamily": "InterUI-Black",
-              "fontSize": 24,
-              "lineHeight": 27.6,
+          <Text
+            secondary={true}
+            style={
+              Object {
+                "color": "rgba(39, 39, 46, 0.6)",
+                "fontFamily": "InterUI-Bold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
             }
-          }
-        >
-          Prayer
-        </Text>
+          >
+            Prayer
+          </Text>
+          <Text
+            primary={true}
+            style={
+              Object {
+                "color": "#27272E",
+                "fontFamily": "InterUI-Black",
+                "fontSize": 24,
+                "lineHeight": 27.6,
+              }
+            }
+          >
+            Example title
+          </Text>
+        </View>
       </View>
       <View
         style={
           Object {
             "flexDirection": "row",
-            "paddingBottom": 32,
+            "paddingBottom": 24,
             "paddingHorizontal": 0,
-            "paddingTop": 16,
+            "paddingTop": 0,
             "paddingVertical": 16,
           }
         }
@@ -6083,36 +6105,38 @@ Array [
     }
   />,
   <View
-    isCard={false}
     style={
       Object {
-        "paddingBottom": 0,
         "paddingHorizontal": 16,
-        "paddingTop": 48,
         "paddingVertical": 16,
       }
     }
   >
-    <Text
-      style={
-        Object {
-          "color": "#27272E",
-          "fontFamily": "InterUI-Black",
-          "fontSize": 24,
-          "lineHeight": 27.6,
-        }
-      }
+    <View
+      style={Object {}}
     >
-      Prayer
-    </Text>
+      <Text
+        secondary={true}
+        style={
+          Object {
+            "color": "rgba(39, 39, 46, 0.6)",
+            "fontFamily": "InterUI-Bold",
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Prayer
+      </Text>
+    </View>
   </View>,
   <View
     style={
       Object {
         "flexDirection": "row",
-        "paddingBottom": 32,
+        "paddingBottom": 24,
         "paddingHorizontal": 0,
-        "paddingTop": 16,
+        "paddingTop": 0,
         "paddingVertical": 16,
       }
     }

--- a/packages/apollos-ui-prayer/src/PrayerFeature/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerFeature/index.js
@@ -5,23 +5,22 @@ import {
   AvatarList,
   Card,
   CardContent,
-  H3,
-  H6,
   ImageSourceType,
   styled,
   withIsLoading,
   withTheme,
+  FeatureTitles,
 } from '@apollosproject/ui-kit';
 
 const AvatarWrapper = styled(
   ({ theme }) => ({
     flexDirection: 'row',
-    paddingBottom: theme.sizing.baseUnit * 2, // TODO: refactor CardContent to have this be the default
+    paddingBottom: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
     // paddingHorizontal: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
     paddingHorizontal: 0,
     /* Because `CardContent` is passing `paddingVertical` to `PaddedView` we can't set
      * `PaddedView`'s `vertical` prop to false. So we have to define out own padding value here. */
-    paddingTop: theme.sizing.baseUnit,
+    paddingTop: 0,
   }),
   'ui-prayer.PrayerFeature.AvatarWrapper'
 )(CardContent);
@@ -32,22 +31,6 @@ const getAvatars = (prayers) =>
     notification: !prayer.isPrayed,
     profile: prayer.requestor,
   }));
-
-const Header = styled(
-  ({ isCard, theme }) => ({
-    ...(isCard
-      ? {
-          paddingHorizontal: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
-        }
-      : {
-          paddingTop: theme.sizing.baseUnit * 3, // // TODO: refactor CardContent to have this be the default
-        }),
-    /* Because `CardContent` is passing `paddingVertical` to `PaddedView` we can't set
-     * `PaddedView`'s `vertical` prop to false. So we have to define out own padding value here. */
-    paddingBottom: 0,
-  }),
-  'ui-prayer.PrayerFeature.Header'
-)(CardContent);
 
 const StyledAvatarList = withTheme(
   ({ isCard, theme }) => ({
@@ -61,17 +44,6 @@ const StyledAvatarList = withTheme(
   }),
   'ui-prayer.PrayerFeature.StyledAvatarList'
 )(AvatarList);
-
-/* TODO: Change to H5 and add appropriate padding. We are using H6 here to be consistant with other
- * "card titles" (`ActionListFeature`). */
-const Title = styled(
-  ({ theme }) => ({
-    color: theme.colors.text.tertiary,
-  }),
-  'ui-prayer.PrayerFeature.Title'
-)(H6);
-
-const Subtitle = styled({}, 'ui-prayer.PrayerFeature.Subtitle')(H3);
 
 const RenderAsCard = ({ children, isCard, isLoading }) =>
   isCard ? <Card isLoading={isLoading}>{children}</Card> : children;
@@ -93,12 +65,13 @@ const PrayerFeature = ({
 }) => (
   <RenderAsCard isCard={isCard} isLoading={isLoading}>
     {isLoading || title || subtitle ? ( // only display the Header if we are loading or have a title/subtitle
-      <Header isCard={isCard}>
-        {isLoading || title ? ( // we check for isloading here so that they are included in the loading state
-          <Title numberOfLines={1}>{title}</Title>
-        ) : null}
-        {isLoading || subtitle ? <Subtitle>{subtitle}</Subtitle> : null}
-      </Header>
+      <CardContent>
+        <FeatureTitles
+          isLoading={isLoading}
+          title={title}
+          subtitle={subtitle}
+        />
+      </CardContent>
     ) : null}
     <AvatarWrapper>
       <StyledAvatarList

--- a/packages/apollos-ui-prayer/src/PrayerFeature/index.js
+++ b/packages/apollos-ui-prayer/src/PrayerFeature/index.js
@@ -13,15 +13,11 @@ import {
 } from '@apollosproject/ui-kit';
 
 const AvatarWrapper = styled(
-  ({ theme }) => ({
+  {
     flexDirection: 'row',
-    paddingBottom: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
-    // paddingHorizontal: theme.sizing.baseUnit * 1.5, // TODO: refactor CardContent to have this be the default
     paddingHorizontal: 0,
-    /* Because `CardContent` is passing `paddingVertical` to `PaddedView` we can't set
-     * `PaddedView`'s `vertical` prop to false. So we have to define out own padding value here. */
     paddingTop: 0,
-  }),
+  },
   'ui-prayer.PrayerFeature.AvatarWrapper'
 )(CardContent);
 


### PR DESCRIPTION
Main things this PR aims to do:

- Makes titles across all features consistent
- Cleans up spacing so we don't have gigantic spacing between some features

New API created:

- Creates a `<FeatureTitles/>` component that matches Figma that can be used across all features for consistent titles
- Adds color-based props to typography components so that we can easily style typography elements. Such as `<H2 secondary />`. These prop names matches the color options in Figma:

![Screen Shot 2021-07-01 at 11 11 40 PM](https://user-images.githubusercontent.com/103927/124219301-b2e7a180-dac1-11eb-8836-1e4e57c93353.png)

I believe our UI-Kit is becoming mature enough that short-hand props like this can make sense, especially since it's saves us from having to create the same `styled` components over and over again.