### PR TITLE
chore: Use more helpful error messages when package imports are wrong

### DIFF
--- a/packages/apollos-server-core/src/index.js
+++ b/packages/apollos-server-core/src/index.js
@@ -22,6 +22,19 @@ export { resolverMerge, schemaMerge } from './utils';
 export { setupUniversalLinks, generateAppLink } from './linking';
 export { Interfaces };
 
+const safeGetWithWarning = (name) => (data, key) => {
+  if (data == null) {
+    console.warn(
+      `The ${key} data object is null.
+      Check to make sure you are importing ${key} from the correct package
+      or that your packages are up to date.
+      `
+    );
+    return null;
+  }
+  return data[name];
+};
+
 // Types that all apollos-church servers will use.
 const builtInData = { Node, Pagination, Media, Message };
 
@@ -35,37 +48,42 @@ export const createSchema = (data) => [
       _placeholder: Boolean # needed, empty schema defs aren't supported
     }
   `,
-  ...compact(values({ ...builtInData, ...data }).map((datum) => datum.schema)),
+  ...compact(
+    mapValues({ ...builtInData, ...data }, safeGetWithWarning('schema'))
+  ),
 ];
 
 export const createResolvers = (data) =>
   merge(
     ...compact(
-      values({ ...builtInData, ...data }).map((datum) => datum.resolver)
+      mapValues({ ...builtInData, ...data }, safeGetWithWarning('resolver'))
     )
   );
 
 const getDbModels = (data) =>
-  mapValues({ ...builtInData, ...data }, (datum) => datum.models);
+  compact(mapValues({ ...builtInData, ...data }, safeGetWithWarning('models')));
 
 const getMigrations = (data) =>
   compact(
     flatten(
-      values({ ...builtInData, ...data }).map((datum) => datum.migrations)
+      mapValues({ ...builtInData, ...data }, safeGetWithWarning('migrations'))
     )
   );
 
 const getDataSources = (data) =>
-  mapValues({ ...builtInData, ...data }, (datum) => datum.dataSource);
+  mapValues({ ...builtInData, ...data }, safeGetWithWarning('dataSource'));
 
 // Deprecated - we won't be using this models paradigm going forward.
 // All models should be renamed as DataSources.
 const getModels = (data) =>
-  mapValues({ ...builtInData, ...data }, (datum) => datum.model);
+  mapValues({ ...builtInData, ...data }, safeGetWithWarning('model'));
 
 const getContextMiddlewares = (data) =>
   compact(
-    values({ ...builtInData, ...data }).map((datum) => datum.contextMiddleware)
+    mapValues(
+      { ...builtInData, ...data },
+      safeGetWithWarning('contextMiddleware')
+    )
   );
 
 export const createDataSources = (data) => {
@@ -170,7 +188,10 @@ export const createContextGetter = (serverConfig) => (data) => {
 
 export const createMiddleware = (data) => ({ app, context, dataSources }) => {
   const middlewares = compact(
-    values({ ...builtInData, ...data }).map((datum) => datum.serverMiddleware)
+    mapValues(
+      { ...builtInData, ...data },
+      safeGetWithWarning('serverMiddleware')
+    )
   );
 
   const getContext = createContextGetter({ context, dataSources });
@@ -180,7 +201,7 @@ export const createMiddleware = (data) => ({ app, context, dataSources }) => {
 
 export const createJobs = (data) => ({ app, context, dataSources }) => {
   const jobs = compact(
-    values({ ...builtInData, ...data }).map((datum) => datum.jobs)
+    mapValues({ ...builtInData, ...data }, safeGetWithWarning('jobs'))
   );
 
   const getContext = createContextGetter({ context, dataSources });

--- a/packages/apollos-server-core/src/index.js
+++ b/packages/apollos-server-core/src/index.js
@@ -1,4 +1,4 @@
-import { compact, mapValues, merge, values, flatten } from 'lodash';
+import { compact, mapValues, merge, flatten } from 'lodash';
 import gql from 'graphql-tag';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { makeExecutableSchema } from 'apollo-server';
@@ -49,24 +49,30 @@ export const createSchema = (data) => [
     }
   `,
   ...compact(
-    mapValues({ ...builtInData, ...data }, safeGetWithWarning('schema'))
+    Object.values(
+      mapValues({ ...builtInData, ...data }, safeGetWithWarning('schema'))
+    )
   ),
 ];
 
 export const createResolvers = (data) =>
   merge(
     ...compact(
-      mapValues({ ...builtInData, ...data }, safeGetWithWarning('resolver'))
+      Object.values(
+        mapValues({ ...builtInData, ...data }, safeGetWithWarning('resolver'))
+      )
     )
   );
 
 const getDbModels = (data) =>
-  compact(mapValues({ ...builtInData, ...data }, safeGetWithWarning('models')));
+  mapValues({ ...builtInData, ...data }, safeGetWithWarning('models'));
 
 const getMigrations = (data) =>
   compact(
     flatten(
-      mapValues({ ...builtInData, ...data }, safeGetWithWarning('migrations'))
+      Object.values(
+        mapValues({ ...builtInData, ...data }, safeGetWithWarning('migrations'))
+      )
     )
   );
 
@@ -80,9 +86,11 @@ const getModels = (data) =>
 
 const getContextMiddlewares = (data) =>
   compact(
-    mapValues(
-      { ...builtInData, ...data },
-      safeGetWithWarning('contextMiddleware')
+    Object.values(
+      mapValues(
+        { ...builtInData, ...data },
+        safeGetWithWarning('contextMiddleware')
+      )
     )
   );
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1637694/124758793-f0eb2800-defc-11eb-89ff-7c1a2355f15b.png)

@redreceipt this stops the wild goose chase for tracking down packages with bad imports way easier. stops the old `can't call property dataSource of undefined` error