### PR TITLE
Fix: race condition in ConnectedImage loading

### DIFF
--- a/packages/apollos-ui-kit/src/ConnectedImage/index.js
+++ b/packages/apollos-ui-kit/src/ConnectedImage/index.js
@@ -63,17 +63,17 @@ const ConnectedImage = ({
   ...imageProps
 }) => {
   const cachedSource = getCachedSources(source);
-  const imageInCache = every(
-    cachedSource,
-    (image) => image.width && image.height
-  );
 
   // Aspect Ratio Calculations
-  const [[width, height], setImageSize] = useState([
+  const [[loadedWidth, loadedHeight], setImageSize] = useState([
     cachedSource[0]?.width,
     cachedSource[0]?.height,
   ]);
   const aspectRatioStyle = {};
+  const [width, height] = [
+    loadedWidth || cachedSource[0]?.width,
+    loadedHeight || cachedSource[0]?.height,
+  ];
 
   if (maintainAspectRatio) {
     aspectRatioStyle.aspectRatio = width && height ? width / height : 1;
@@ -95,11 +95,14 @@ const ConnectedImage = ({
 
   const handleOnLoad = (e) => {
     if (onLoad) onLoad(e);
-    if (!imageInCache) {
-      const {
-        nativeEvent: { source: loadedSource },
-      } = e;
-      updateCache(loadedSource);
+    const {
+      nativeEvent: { source: loadedSource },
+    } = e;
+    updateCache(loadedSource);
+    if (
+      loadedWidth !== loadedSource.width ||
+      loadedHeight !== loadedSource.height
+    ) {
       setImageSize([loadedSource.width, loadedSource.height]);
     }
   };

--- a/packages/apollos-ui-kit/src/ConnectedImage/index.js
+++ b/packages/apollos-ui-kit/src/ConnectedImage/index.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Animated } from 'react-native';
 import PropTypes from 'prop-types';
-import { every } from 'lodash';
 
 import styled from '../styled';
 


### PR DESCRIPTION
This fixes a race condition in the way ConnectedImage detects image size that I've only been able to replicate on River Valley and FNWA apps. The issue causes non-square images to be square the first time you open a content single with that image. The next time you open it, the image is the proper aspect ratio.

Here's my best explanation of what happens...but you should reference the first few lines in `ConnectedImage` component that's on master, here they are:

```jsx
const ConnectedImage = ({
  source,
  // ...otherProps
}) => {
  const cachedSource = getCachedSources(source); // This gets a "cached" version of our source image that contains width and height keys
  const imageInCache = every( // used to determine whether `handleOnLoad` callback below should run
    cachedSource,
    (image) => image.width && image.height
  );

  // Aspect Ratio Calculations - used in setting `style={{ aspectRatio }}` on <Image /> in render
  const [[width, height], setImageSize] = useState([
    cachedSource[0]?.width,
    cachedSource[0]?.height,
  ]);

  // Also, notice this function a little later in the component:
  const handleOnLoad = (e) => {
    if (onLoad) onLoad(e);
    if (!imageInCache) {
      const {
        nativeEvent: { source: loadedSource },
      } = e;
      updateCache(loadedSource);
      setImageSize([loadedSource.width, loadedSource.height]);
    }
  };
```

- When opening a `NodeSingle` for the first time the `node(id: '...')` query is not in cache, so the component temporarily mounts in an empty loading state, and the `ConnectedImage` component on this screen mounts with an empty `source={}`
- At this point, looking at the code above, both `source` an `cachedSource` is `undefined`
- This means that the `width` and `height` state initializes as `undefined` as well
- Once the `node(id: '..')` query loads, the component updates with an image source, and that image source is already in our image cache, so now both `source` and `cachedSource` has values, and the `imageInCache` variable switches to `true`
- However, `width` and `height` is still `undefined` since that is state, and prop updates won't change what the state was initially mounted as
- Later, the `handleOnLoad` is fired, but since `imageInCache` is truthy, `setImageSize` is never called, leaving `width` and `height` set to `undefined`, which means `aspectRatio` stays defaulted (which is `1` in this case)


This PR fixes this problem by removing the `imageInCache` check and instead calling `setImageSize` whenever the loaded values for `width` or `height` don't match state. This PR also introduces an optimization that prevents the loaded image from temporarily mounting as square, then reverting to a widescreen aspect ratio by making the `width` and `height` variables calculated at every render, instead of just as default state.

This means nice and smooth image loading with less jumpiness and proper aspect ratios! ⚡️