### PR TITLE
chore: data-schema peer dep

### DIFF
--- a/packages/apollos-data-connector-rock/package.json
+++ b/packages/apollos-data-connector-rock/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@apollosproject/config": "*",
-    "@apollosproject/data-schema": "*",
+    "@apollosproject/data-schema": ">=2.26.0",
     "@apollosproject/rock-apollo-data-source": "*",
     "@apollosproject/server-core": "*"
   },


### PR DESCRIPTION
prevents `Event.title not in schema` error
