### PR TITLE
fix: Added Order to the contentItems

### DIFF
--- a/packages/apollos-data-connector-postgres/src/content-items/dataSource.js
+++ b/packages/apollos-data-connector-postgres/src/content-items/dataSource.js
@@ -173,6 +173,7 @@ class ContentItemDataSource extends PostgresDataSource {
         contentItemCategoryId: { [Op.in]: ids },
         ...args?.where,
       },
+      order: [['publish_at', 'DESC']],
     });
   };
 


### PR DESCRIPTION
Added order to the Sequelize query for getFromCategoryIds. This makes the most recent items return from Postgres. May need to add the order option to the other queries. 