### PR TITLE
fix: Add isPublic column to prayers

### DIFF
--- a/packages/apollos-data-connector-postgres/src/prayers/migrations/007_add_prayer_ispublic_field.js
+++ b/packages/apollos-data-connector-postgres/src/prayers/migrations/007_add_prayer_ispublic_field.js
@@ -1,0 +1,16 @@
+import { DataTypes } from 'sequelize';
+
+async function up({ context: queryInterface }) {
+  await queryInterface.addColumn('prayer_request', 'isPublic', {
+    type: DataTypes.BOOLEAN,
+    defaultValue: false,
+  });
+}
+
+async function down({ context: queryInterface }) {
+  await queryInterface.removeColumn('prayer_request', 'isPublic');
+}
+
+const name = '005-add-prayer-approved-field';
+
+module.exports = { up, down, name, order: 7 };

--- a/packages/apollos-data-connector-postgres/src/prayers/model.js
+++ b/packages/apollos-data-connector-postgres/src/prayers/model.js
@@ -9,6 +9,7 @@ const createModel = defineModel({
     originId: DataTypes.TEXT,
     originType: DataTypes.TEXT,
     approved: DataTypes.BOOLEAN,
+    isPublic: DataTypes.BOOLEAN,
     flagCount: DataTypes.INTEGER,
   },
   sequelizeOptions: {


### PR DESCRIPTION
The current model does not include ispublic flag from rock. We use this to allow people to submit "confidential" prayers. We don't want these to show up in the app. but having this flag could allow for us to let staff or pastoral staff see these prayers in the app. 